### PR TITLE
Frontend Path tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ backend/*/src/main/resources/3rdPartyLicenses/**
 # --------------------------------------
 
 .env
+!frontend/.env
 
 # Ignore Node
 frontend/node/**

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
-# Build Container
-FROM maven:3-amazoncorretto-15
+# Vue Build Container
+FROM node:lts-alpine as VUE
+WORKDIR /frontend
+COPY frontend .
+RUN npm install && npm run license-check && npm run license && npm run build
+
+# Micronaut build
+FROM maven:3-amazoncorretto-15 as MAVEN
 
 WORKDIR /home/maven/backend
 
@@ -7,18 +13,20 @@ WORKDIR /home/maven/backend
 COPY backend/pom.xml backend/formatter.xml ./
 COPY backend/business-partner-agent ./business-partner-agent
 COPY backend/business-partner-agent-core ./business-partner-agent-core
-COPY frontend ../frontend
+# Copy Vue App
+COPY --from=VUE ["/frontend/licenses/[^attribution]*", "./business-partner-agent/src/main/resources/3rdPartyLicenses"]
+COPY --from=VUE /frontend/dist ./business-partner-agent/src/main/resources/public
 
 # Cache Maven Artefacts
 RUN mvn dependency:go-offline || true
 
 # Build .jar
-RUN mvn clean install -P build-frontend -DskipTests=true -Dspotbugs.skip=true -Dpmd.skip=true
+RUN mvn clean install -DskipTests=true -Dspotbugs.skip=true -Dpmd.skip=true
 
 # Runtime Container
 FROM amazoncorretto:15-alpine
-COPY --from=0 /home/maven/backend/business-partner-agent/target/business-partner-agent*SNAPSHOT.jar business-partner-agent.jar
-COPY --from=0 /home/maven/backend/business-partner-agent/src/main/resources/3rdPartyLicenses ./3rdPartyLicenses
+COPY --from=MAVEN /home/maven/backend/business-partner-agent/target/business-partner-agent*SNAPSHOT.jar business-partner-agent.jar
+COPY --from=MAVEN /home/maven/backend/business-partner-agent/src/main/resources/3rdPartyLicenses ./3rdPartyLicenses
 
 EXPOSE 8080
 CMD java -XX:+UnlockExperimentalVMOptions -Dcom.sun.management.jmxremote -noverify ${JAVA_OPTS} -jar business-partner-agent.jar

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,3 @@
+VUE_APP_TITLE=Business Partner Agent
+VUE_APP_API_BASE_URL=/api
+VUE_APP_EVENTS_PATH=events

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,14 +39,14 @@
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-vue": "^6.2.2",
     "husky": "^4.3.0",
+    "license-checker": "25.0.1",
     "lint-staged": "^10.4.2",
     "oss-attribution-generator": "^1.7.1",
     "prettier": "2.1.2",
     "vue-cli-plugin-vuetify": "^2.0.7",
     "vue-jest": "^3.0.7",
     "vue-template-compiler": "^2.6.12",
-    "xml-js": "^1.6.11",
-    "license-checker": "25.0.1"
+    "xml-js": "^1.6.11"
   },
   "husky": {
     "hooks": {

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <!-- <link rel="icon" href="<%= BASE_URL %>favicon.ico"> -->
-    <title>Business Partner Agent</title>
+    <title><%= process.env.VUE_APP_TITLE %></title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" integrity="sha384-vp86vTRFVJgpjF9jiIGPEEqYqlDwgyBgEF109VFjmqGmIY/Y4HV4d3Gp2irVfcrp" crossorigin="anonymous">
   </head>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2,7 +2,7 @@
  Copyright (c) 2020 - for information on the respective copyright owner
  see the NOTICE file and/or the repository at
  https://github.com/hyperledger-labs/organizational-agent
- 
+
  SPDX-License-Identifier: Apache-2.0
 */
 
@@ -23,22 +23,15 @@ Vue.component("vue-json-pretty", VueJsonPretty);
 Vue.use(require("vue-moment"));
 Vue.use(SortUtil);
 
-var apiBaseUrl;
-var socketApi;
+var apiBaseUrl = process.env.VUE_APP_API_BASE_URL;
+var eventsHost = process.env.VUE_APP_EVENTS_HOST ? process.env.VUE_APP_EVENTS_HOST : window.location.host;
+var socketApi = `${window.location.protocol === "https:" ? "wss" : "ws"}://${eventsHost}/${process.env.VUE_APP_EVENTS_PATH}`;
+
 if (process.env.NODE_ENV === "development") {
-  apiBaseUrl = "http://localhost:8080/api";
-  socketApi = `${
-    window.location.protocol === "https:" ? "wss" : "ws"
-  }://localhost:8080/events`;
   store.commit({
     type: "setExpertMode",
     isExpert: true,
   });
-} else {
-  apiBaseUrl = "/api";
-  socketApi = `${window.location.protocol === "https:" ? "wss" : "ws"}://${
-    window.location.host
-  }/events`;
 }
 
 Vue.use(VueNativeSock, socketApi, {


### PR DESCRIPTION
Allow frontend to read configuration for where the API and events paths are hosted; this is more for different types of local development but useful for breaking the hardcoded dependency on frontend relative to backend.

Signed-off-by: Jason Sherman <jsherman@parcsystems.ca>

Replaces #369 as that PR had these changes and changes for #368 included. Breaking 369 into 2 PRs, as 368 has been updated too.