### PR TITLE
Helm agent secrets

### DIFF
--- a/charts/bpa/templates/_helpers.tpl
+++ b/charts/bpa/templates/_helpers.tpl
@@ -79,6 +79,22 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+generate hosts if not overriden
+*/}}
+{{- define "bpa.ingressHosts" -}}
+{{- if .Values.acapy.ingress.hosts -}}
+{{- .Values.acapy.ingress.hosts -}}
+{{- else }}
+hosts:
+- host: {{ printf "%s-%s-%s" $.Release.Name ( include "bpa.fullname" . ) $.Values.global.ingressSuffix | quote }}
+  http:
+  paths:
+    - path: /
+{{- end -}}
+{{- end }}
+
+
+{{/*
 Common acapy labels
 */}}
 {{- define "acapy.labels" -}}
@@ -97,6 +113,22 @@ Selector acapy labels
 app.kubernetes.io/name: {{ include "global.fullname" . }}-{{ .Values.acapy.name }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+generate hosts if not overriden
+*/}}
+{{- define "acapy.ingressHosts" -}}
+{{- if .Values.acapy.ingress.hosts -}}
+{{- .Values.acapy.ingress.hosts -}}
+{{- else }}
+hosts:
+- host: {{ printf "%s-%s-%s" $.Release.Name ( include "acapy.fullname" . ) $.Values.global.ingressSuffix | quote }}
+  http:
+  paths:
+    - path: /
+{{- end -}}
+{{- end }}
+
 
 {{/*
 Create a default fully qualified app name for the postgres requirement.

--- a/charts/bpa/templates/acapy_deployment.yaml
+++ b/charts/bpa/templates/acapy_deployment.yaml
@@ -31,19 +31,21 @@ spec:
           imagePullPolicy: {{ .Values.acapy.image.pullPolicy }}
           args: [
            "-c",
-           "sleep 15; \
-           aca-py start \  
+           "curl -d '{\"seed\":\"$(WALLET_SEED)\", \"role\":\"TRUST_ANCHOR\", \"alias\":\"{{ include "bpa.fullname" . }}\"}' -X POST {{ .Values.bpa.config.ledger.browser }}/register; \
+           sleep 15; \
+           aca-py start \     
+           --auto-provision \
            --arg-file acapy-static-args.yml \   
            --inbound-transport http '0.0.0.0' {{ .Values.acapy.service.httpPort }} \ 
            --webhook-url http://{{ include "bpa.fullname" . }}:{{ .Values.bpa.service.port }}/log \
            --genesis-url '{{ .Values.bpa.config.ledger.browser }}/genesis' \
-           --endpoint https://{{ (index .Values.acapy.ingress.hosts 0).host }} \
+           --endpoint http://{{ (index .acapy.ingressHosts 0).host }} \
            --wallet-storage-type 'postgres_storage' \
            --wallet-name 'mywallet' \
            --wallet-key '123' \
            --wallet-storage-config '{\"url\":\"{{ include "global.postgresql.fullname" . }}:{{ .Values.postgresql.service.port }}\",\"max_connections\":5}' \
            --wallet-storage-creds '{\"account\":\"{{ .Values.postgresql.postgresqlUsername }}\",\"password\":\"$(POSTGRES_PASSWORD)\",\"admin_account\":\"{{ .Values.postgresql.postgresqlUsername }}\",\"admin_password\":\"$(POSTGRES_PASSWORD)\"}' \ 
-           --seed '{{ .Values.acapy.agentSeed }}' \
+           --seed \"$(WALLET_SEED)\" \
            --admin '0.0.0.0' {{ .Values.acapy.service.adminPort }} \
            --admin-insecure-mode \
            --label {{ .Values.acapy.agentName }} \
@@ -66,7 +68,12 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ template "global.postgresql.fullname" . }}
-                  key: postgresql-password  
+                  key: postgresql-password         
+            - name: WALLET_SEED
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "acapy.fullname" . }}
+                  key: seed 
           livenessProbe:
             httpGet:
               path: /status/live 

--- a/charts/bpa/templates/acapy_ingress.yaml
+++ b/charts/bpa/templates/acapy_ingress.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.acapy.ingress.enabled -}}
 {{- $fullName := include "acapy.fullname" . -}}
 {{- $svcPort := .Values.acapy.service.httpPort -}}
+{{- $acapyIngressHosts := include "acapy.ingressHosts" .hosts -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
@@ -27,7 +28,7 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    {{- range .Values.acapy.ingress.hosts }}
+    {{- range $acapyIngressHosts }}
     - host: {{ .host | quote }}
       http:
         paths:

--- a/charts/bpa/templates/acapy_secret.yaml
+++ b/charts/bpa/templates/acapy_secret.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    "helm.sh/resource-policy": keep
+  name: {{ template "acapy.fullname" . }}
+  labels:
+    app: {{ template "global.name" . }}
+    chart: {{ template "global.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+type: Opaque
+data:
+  {{ if (lookup "v1" "Secret" .Release.Namespace (include "acapy.fullname" .)) -}}
+  seed: {{ index (lookup "v1" "Secret" .Release.Namespace (include "acapy.fullname" .)).data "seed" }}
+  {{- else -}}
+  seed: {{ randAlphaNum 32 | b64enc | quote }}
+  {{- end -}} 

--- a/charts/bpa/templates/bpa_configmap.yaml
+++ b/charts/bpa/templates/bpa_configmap.yaml
@@ -1,3 +1,4 @@
+{{- $acapyIngressHosts := include "acapy.ingressHosts" .hosts -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,11 +12,11 @@ data:
       acapy:
         url: http://{{ include "acapy.fullname" . }}:{{ .Values.acapy.service.adminPort }} 
         apiKey: {{ .Values.acapy.adminURLApiKey }}
-        endpoint: https://{{ (index .Values.acapy.ingress.hosts 0).host }}  
+        endpoint: https://{{ (index $acapyIngressHosts 0).host }}  
       pg:
         url: jdbc:postgresql://{{ include "global.postgresql.fullname" . }}/{{ .Values.postgresql.postgresqlUsername }}
         username: {{ .Values.postgresql.postgresqlUsername }}
-      host: {{ (index .Values.bpa.ingress.hosts 0).host }}
+      host: {{ (index $acapyIngressHosts 0).host }}
       micronaut:
         security:
           enabled: {{ .Values.bpa.config.security.enabled }}

--- a/charts/bpa/templates/bpa_ingress.yaml
+++ b/charts/bpa/templates/bpa_ingress.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.bpa.ingress.enabled -}}
 {{- $fullName := include "bpa.fullname" . -}}
 {{- $svcPort := .Values.bpa.service.port -}}
+{{- $bpaIngressHosts := include "bpa.ingressHosts" .hosts -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
@@ -27,7 +28,7 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    {{- range .Values.bpa.ingress.hosts }}
+    {{- range $bpaIngressHosts }}
     - host: {{ .host | quote }}
       http:
         paths:

--- a/charts/bpa/values.yaml
+++ b/charts/bpa/values.yaml
@@ -6,6 +6,10 @@ global:
   nameOverride: ""
   fullnameOverride: ""
 
+  #Define domain and allow auto-generated hostpaths 
+  ## define <service>.ingress.hosts.host to override
+  ingressSuffix: f6b17d-dev.apps.silver.devops.gov.bc.ca
+
   persistence:
     # -- If true, the Postgres chart is deployed
     deployPostgres: true
@@ -83,13 +87,14 @@ bpa:
     port: 80
 
   ingress:
-    enabled: false
+    enabled: true
     annotations: {}
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
-    hosts:
-      - host: my-bpa.local
-        paths: []
+    # Uncomment this to define your own hosts and override global.ingressSuffix
+    # hosts: 
+    #     host:
+    #     paths: ['/']
     tls: []
     #  - secretName: my-bpa-tls
     #    hosts:
@@ -122,9 +127,6 @@ acapy:
     # --  Overrides the image tag whose default is the chart appVersion.
     tag: py36-1.16-0_0.6.0
 
-  # -- (String) The agent seed, 32 characters. See main documentation. 
-  agentSeed:
-
   adminURLApiKey: 2f9729eef0be49608c1cffd49ee3cc4a
 
   agentName: ca-aca-py
@@ -154,13 +156,15 @@ acapy:
     httpPort: 8030
 
   ingress:
-    enabled: false
+    enabled: true
     annotations: {}
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
-    hosts:
-      - host: my-acapy.local
-        paths: []
+
+    # Uncomment this to define your own hosts and override global.ingressSuffix
+    # hosts: 
+    #     host:
+    #     paths: ['/']
     tls: []
     #  - secretName: my-acapy-tls
     #    hosts:


### PR DESCRIPTION
moved from #381, using origin repo instead of fork so @frank-bee can help!

Move acapy seed to k8s secret (Created and annotated to be kept on uninstall)
add release.name to ingress path for easier multiple deployments. 
 - _improving that to generate with suffix, or overridden with full yaml block_
