### PR TITLE
don't overwrite acapy-seed if secret already exists

### DIFF
--- a/charts/bpa/templates/acapy_secret.yaml
+++ b/charts/bpa/templates/acapy_secret.yaml
@@ -10,5 +10,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
-  seed: {{ include "acapy.seed" . | b64enc | quote }}
-{{- end -}}
+  {{ if (lookup "v1" "Secret" .Release.Namespace (include "acapy.fullname" .)) -}}
+  seed: {{ index (lookup "v1" "Secret" .Release.Namespace (include "acapy.fullname" .)).data "seed" }}
+  {{- else -}}
+  seed: {{ randAlphaNum 32 | b64enc | quote }}
+  {{- end -}} 


### PR DESCRIPTION
Upgrading the helm deployment re-rolls the acapy seed, which is bad. if a secret already exists, this will preserve it. 

Signed-off-by: Jason Sy <jasyrotuck@gmail.com>