### PR TITLE
Refactor Helm Charts add support for Keycloak and Schemas

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 # Dockerfile that builds frontend and backend, mainly used by the docker-compose files
 
 # Vue Build Container
-FROM node:lts-alpine as VUE
+FROM docker.io/node:lts-alpine as VUE
 WORKDIR /frontend
 COPY frontend .
 RUN npm install && npm run license && npm run build
 
 # Micronaut build
-FROM maven:3-amazoncorretto-15 as MAVEN
+FROM docker.io/maven:3-amazoncorretto-15 as MAVEN
 
 WORKDIR /home/maven
 
@@ -25,7 +25,7 @@ RUN mvn dependency:go-offline || true
 RUN mvn clean package -DskipTests=true -Dspotbugs.skip=true -Dpmd.skip=true
 
 # Runtime Container
-FROM amazoncorretto:15-alpine
+FROM docker.io/amazoncorretto:15-alpine
 COPY --from=MAVEN /home/maven/business-partner-agent/target/business-partner-agent*SNAPSHOT.jar business-partner-agent.jar
 
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 # Dockerfile that builds frontend and backend, mainly used by the docker-compose files
 
 # Vue Build Container
-FROM docker-remote.artifacts.developer.gov.bc.ca/node:lts-alpine as VUE
+FROM node:lts-alpine as VUE
 WORKDIR /frontend
 COPY frontend .
 RUN npm install && npm run license && npm run build
 
 # Micronaut build
-FROM docker-remote.artifacts.developer.gov.bc.ca/maven:3-amazoncorretto-15 as MAVEN
+FROM maven:3-amazoncorretto-15 as MAVEN
 
 WORKDIR /home/maven
 
@@ -25,7 +25,7 @@ RUN mvn dependency:go-offline || true
 RUN mvn clean package -DskipTests=true -Dspotbugs.skip=true -Dpmd.skip=true
 
 # Runtime Container
-FROM docker-remote.artifacts.developer.gov.bc.ca/amazoncorretto:15-alpine
+FROM amazoncorretto:15-alpine
 COPY --from=MAVEN /home/maven/business-partner-agent/target/business-partner-agent*SNAPSHOT.jar business-partner-agent.jar
 
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 # Dockerfile that builds frontend and backend, mainly used by the docker-compose files
 
 # Vue Build Container
-FROM docker-remote.artifacts.developer.gov.bc.ca/node:lts-alpine as VUE
+FROM docker.io/node:lts-alpine as VUE
 WORKDIR /frontend
 COPY frontend .
 RUN npm install && npm run license && npm run build
 
 # Micronaut build
-FROM docker-remote.artifacts.developer.gov.bc.ca/maven:3-amazoncorretto-15 as MAVEN
+FROM docker.io/maven:3-amazoncorretto-15 as MAVEN
 
 WORKDIR /home/maven
 
@@ -25,7 +25,7 @@ RUN mvn dependency:go-offline || true
 RUN mvn clean package -DskipTests=true -Dspotbugs.skip=true -Dpmd.skip=true
 
 # Runtime Container
-FROM docker-remote.artifacts.developer.gov.bc.ca/amazoncorretto:15-alpine
+FROM docker.io/amazoncorretto:15-alpine
 COPY --from=MAVEN /home/maven/business-partner-agent/target/business-partner-agent*SNAPSHOT.jar business-partner-agent.jar
 
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 # Dockerfile that builds frontend and backend, mainly used by the docker-compose files
 
 # Vue Build Container
-FROM docker.io/node:lts-alpine as VUE
+FROM docker-remote.artifacts.developer.gov.bc.ca/node:lts-alpine as VUE
 WORKDIR /frontend
 COPY frontend .
 RUN npm install && npm run license && npm run build
 
 # Micronaut build
-FROM docker.io/maven:3-amazoncorretto-15 as MAVEN
+FROM docker-remote.artifacts.developer.gov.bc.ca/maven:3-amazoncorretto-15 as MAVEN
 
 WORKDIR /home/maven
 
@@ -25,7 +25,7 @@ RUN mvn dependency:go-offline || true
 RUN mvn clean package -DskipTests=true -Dspotbugs.skip=true -Dpmd.skip=true
 
 # Runtime Container
-FROM docker.io/amazoncorretto:15-alpine
+FROM docker-remote.artifacts.developer.gov.bc.ca/amazoncorretto:15-alpine
 COPY --from=MAVEN /home/maven/business-partner-agent/target/business-partner-agent*SNAPSHOT.jar business-partner-agent.jar
 
 EXPOSE 8080

--- a/backend/business-partner-agent/src/main/resources/application.yml
+++ b/backend/business-partner-agent/src/main/resources/application.yml
@@ -106,7 +106,7 @@ bpa:
     url: ${BPA_RESOLVER_URL:`https://resolver.stage.economyofthings.io`}
   ledger:
     browser: ${BPA_LEDGER_BROWSER:}
-  host: ${BPA_HOST:localhost:${micronaut.server.port}}
+  host: ${BPA_HOST:`localhost:${micronaut.server.port}`}
   name: ${AGENT_NAME:`Business Partner Agent`}
   scheme: ${BPA_SCHEME:`https`}
   web:

--- a/backend/business-partner-agent/src/main/resources/application.yml
+++ b/backend/business-partner-agent/src/main/resources/application.yml
@@ -106,7 +106,7 @@ bpa:
     url: ${BPA_RESOLVER_URL:`https://resolver.stage.economyofthings.io`}
   ledger:
     browser: ${BPA_LEDGER_BROWSER:}
-  host: ${BPA_HOST:`localhost:${micronaut.server.port}`}
+  host: ${BPA_HOST:`localhost:8080`}
   name: ${AGENT_NAME:`Business Partner Agent`}
   scheme: ${BPA_SCHEME:`https`}
   web:

--- a/backend/business-partner-agent/src/main/resources/application.yml
+++ b/backend/business-partner-agent/src/main/resources/application.yml
@@ -9,6 +9,7 @@ micronaut:
       enabled: true # potential security risk
     idle-timeout: 30m
   security:
+    enabled: ${BPA_SECURITY_ENABLED:true}
     authentication: session
     endpoints:
       logout:
@@ -105,42 +106,25 @@ bpa:
     url: ${BPA_RESOLVER_URL:`https://resolver.stage.economyofthings.io`}
   ledger:
     browser: ${BPA_LEDGER_BROWSER:}
-  host: localhost:${micronaut.server.port}
+  host: ${BPA_HOST:localhost:${micronaut.server.port}}
   name: ${AGENT_NAME:`Business Partner Agent`}
-  scheme: https
+  scheme: ${BPA_SCHEME:`https`}
   web:
     only: ${BPA_WEB_MODE:false}
   acapy:
-    url: http://${bpa.docker.host}:8031
-    apiKey: empty
+    url: ${ACAPY_URL:`http://localhost:8031`}
+    apiKey: ${ACAPY_API_KEY:empty}
     endpoint: ${ACAPY_ENDPOINT:`http://localhost:8030`}
   did:
     prefix: ${BPA_DID_PREFIX:`did:sov:iil:`}
   pg:
-    url: jdbc:postgresql://${bpa.docker.host}/${bpa.pg.username}
-    username: walletuser
-    password: walletpassword
+    url: jdbc:postgresql://${POSTGRESQL_HOST:`localhost`}/${bpa.pg.username}
+    username: ${POSTGRESQL_USER:`walletuser`}
+    password: ${POSTGRESQL_PASSWORD:`walletpassword`}
     schema: public
   bootstrap:
     username: ${BPA_BOOTSTRAP_UN:admin}
     password: ${BPA_BOOTSTRAP_PW:changeme}
-  schemas:
-    #test ledger schemas, can be overwritten / extended when e.g. working with other ledger
-    bank-account:
-      id: "M6Mbe3qx7vB4wpZF4sBRjt:2:bank_account:1.0"
-      label: "Bank Account"
-      defaultAttributeName: "iban"
-      # Note: this also works json style restrictions: [{id: 123, label: myLabel}]
-      restrictions:
-        - issuerDid: "${bpa.did.prefix}M6Mbe3qx7vB4wpZF4sBRjt"
-          label: "Demo Bank"
-    commercial-register:
-      id: "5mwQSWnRePrZ3oF67C4KqD:2:commercialregister:1.0"
-      label: "Commercial Register"
-      defaultAttributeName: "companyName"
-      restrictions:
-        - issuerDid: "${bpa.did.prefix}5mwQSWnRePrZ3oF67C4KqD"
-          label: "Commercial Register"
   imprint:
     url: ${BPA_IMPRINT_URL:}
   privacy:

--- a/backend/business-partner-agent/src/main/resources/schemas.yml
+++ b/backend/business-partner-agent/src/main/resources/schemas.yml
@@ -1,0 +1,18 @@
+bpa:
+  schemas:
+    #test ledger schemas, can be overwritten / extended when e.g. working with other ledger
+    bank-account:
+      id: "M6Mbe3qx7vB4wpZF4sBRjt:2:bank_account:1.0"
+      label: "Bank Account"
+      defaultAttributeName: "iban"
+      # Note: this also works json style restrictions: [{id: 123, label: myLabel}]
+      restrictions:
+        - issuerDid: "${bpa.did.prefix}M6Mbe3qx7vB4wpZF4sBRjt"
+          label: "Demo Bank"
+    commercial-register:
+      id: "5mwQSWnRePrZ3oF67C4KqD:2:commercialregister:1.0"
+      label: "Commercial Register"
+      defaultAttributeName: "companyName"
+      restrictions:
+        - issuerDid: "${bpa.did.prefix}5mwQSWnRePrZ3oF67C4KqD"
+          label: "Commercial Register"

--- a/charts/bpa/README.md
+++ b/charts/bpa/README.md
@@ -178,7 +178,7 @@ Note: Deleting the PVC's will delete postgresql data as well. Please be cautious
 | acapy.nameOverride | string | `""` |  |
 | acapy.nodeSelector | object | `{}` |  |
 | acapy.openshift.route.enabled | bool | `false` | Set to true and acapy.ingress.enabled to false to use Openshift route templates |
-| acapy.openshift.route | object | `{"enabled": false, "path": "/", "targetPort": "http", "tls": { "enabled": true, "insecureEdgeTerminationPolicy": "None", "termination": "edge" }, "wildcardPolicy": "None" }` | Configuration for the route, https/tls is optional |
+| acapy.openshift.route | object | `{"enabled": false, "path": "/", "targetPort": "http", "timeout": "30s", "tls": { "enabled": true, "insecureEdgeTerminationPolicy": "None", "termination": "edge" }, "wildcardPolicy": "None" }` | Configuration for the route, https/tls is optional |
 | acapy.podAnnotations | object | `{}` |  |
 | acapy.podSecurityContext | object | `{}` |  |
 | acapy.readOnlyMode | bool | `false` |  |
@@ -201,7 +201,7 @@ Note: Deleting the PVC's will delete postgresql data as well. Please be cautious
 | bpa.name | string | `"bpacore"` |  |
 | bpa.nodeSelector | object | `{}` |  |
 | bpa.openshift.route.enabled | bool | `false` | Set to true and bpa.ingress.enabled to false to use Openshift route templates |
-| bpa.openshift.route | object | `{"enabled": false, "path": "/", "targetPort": "http", "tls": { "enabled": true, "insecureEdgeTerminationPolicy": "None", "termination": "edge" }, "wildcardPolicy": "None" }` | Configuration for the route, https/tls is optional |
+| bpa.openshift.route | object | `{"enabled": false, "path": "/", "targetPort": "http", "timeout": "30s", "tls": { "enabled": true, "insecureEdgeTerminationPolicy": "None", "termination": "edge" }, "wildcardPolicy": "None" }` | Configuration for the route, https/tls is optional |
 | bpa.podAnnotations | object | `{}` |  |
 | bpa.podSecurityContext | object | `{}` |  |
 | bpa.resources | object | `{}` |  |

--- a/charts/bpa/README.md
+++ b/charts/bpa/README.md
@@ -177,6 +177,8 @@ Note: Deleting the PVC's will delete postgresql data as well. Please be cautious
 | acapy.name | string | `"acapy"` |  |
 | acapy.nameOverride | string | `""` |  |
 | acapy.nodeSelector | object | `{}` |  |
+| acapy.openshift.route.enabled | bool | `false` | Set to true and acapy.ingress.enabled to false to use Openshift route templates |
+| acapy.openshift.route | object | `{"enabled": false, "path": "/", "targetPort": "http", "tls": { "enabled": true, "insecureEdgeTerminationPolicy": "None", "termination": "edge" }, "wildcardPolicy": "None" }` | Configuration for the route, https/tls is optional |
 | acapy.podAnnotations | object | `{}` |  |
 | acapy.podSecurityContext | object | `{}` |  |
 | acapy.readOnlyMode | bool | `false` |  |
@@ -185,6 +187,7 @@ Note: Deleting the PVC's will delete postgresql data as well. Please be cautious
 | acapy.service.adminPort | int | `8031` |  |
 | acapy.service.httpPort | int | `8030` |  |
 | acapy.service.type | string | `"ClusterIP"` |  |
+| acapy.staticArgs | object | `{"autoAcceptInvites": true, "autoAcceptRequests": true, "autoRespondMessages": true, "autoRespondCredentialProposal": true, "autoRespondCredentialOffer": true, "autoRespondCredentialRequest": true, "autoRespondPresentationProposal": true, "autoRespondPresentationRequest": true, "autoStoreCredential": true, "autoVerifyPresentation": true, "autoPingConnection": true, "autoProvision": true, "monitorPing": true, "publicInvites": true, "logLevel": "info" }` | Set all the arguments for the acapy agent   |
 | acapy.tolerations | list | `[]` |  |
 | bpa.affinity | object | `{}` |  |
 | bpa.config | object | `{"bootstrap":{"password":"changeme","username":"admin"},"creddef":{"revocationRegistrySize":3000},"ledger":{"browser":"https://indy-test.bosch-digital.de"},"name":"Business Partner Agent","resolver":{"url":"https://resolver.stage.economyofthings.io"},"security":{"enabled":true},"web":{"only":false}}` | application config (remark: all new configuration values will sit here, the other ones can be migrated step by step) |
@@ -197,6 +200,8 @@ Note: Deleting the PVC's will delete postgresql data as well. Please be cautious
 | bpa.ingress.tls | list | `[]` |  |
 | bpa.name | string | `"bpacore"` |  |
 | bpa.nodeSelector | object | `{}` |  |
+| bpa.openshift.route.enabled | bool | `false` | Set to true and bpa.ingress.enabled to false to use Openshift route templates |
+| bpa.openshift.route | object | `{"enabled": false, "path": "/", "targetPort": "http", "tls": { "enabled": true, "insecureEdgeTerminationPolicy": "None", "termination": "edge" }, "wildcardPolicy": "None" }` | Configuration for the route, https/tls is optional |
 | bpa.podAnnotations | object | `{}` |  |
 | bpa.podSecurityContext | object | `{}` |  |
 | bpa.resources | object | `{}` |  |
@@ -211,6 +216,10 @@ Note: Deleting the PVC's will delete postgresql data as well. Please be cautious
 | global.ingressSuffix | string | `".example.com"` |  |
 | global.nameOverride | string | `""` |  |
 | global.persistence.deployPostgres | bool | `true` | If true, the Postgres chart is deployed |
+| keycloak.enabled | bool | `false` | If true, adds security-keycloak.yml to micronaut config files |
+| keycloak.clientId | string |  | name of client in keycloak realm |
+| keycloak.clientSecret | string |  | value of client secret in keycloak realm |
+| keycloak.config | object | `{"rolesName": "roles", "nameKey": "preferred_username", "redirectUri": "${bpa.scheme}://${bpa.host}/logout", "scopes": "openid", "issuer": "<your keycloak realm issuer url>", "endsessionUrl": "<your keycloak realm end session url>" }` | configuration data, stored in ConfigMap, read by security-keycloak.yml |
 | postgresql.image.tag | int | `12` |  |
 | postgresql.persistence | object | `{"enabled":false}` | Persistent Volume Storage configuration. ref: https://kubernetes.io/docs/user-guide/persistent-volumes |
 | postgresql.persistence.enabled | bool | `false` | Enable PostgreSQL persistence using Persistent Volume Claims. |
@@ -218,6 +227,8 @@ Note: Deleting the PVC's will delete postgresql data as well. Please be cautious
 | postgresql.postgresqlPassword | string | `"change-me"` | PostgreSQL Password for the new user. If not set, a random 10 characters password will be used. |
 | postgresql.postgresqlUsername | string | `"postgres"` | PostgreSQL User to create. Do not change - otherwise non-admin user is created! |
 | postgresql.service | object | `{"port":5432}` | PostgreSQL service configuration |
+| schemas.enabled | bool | `false` | If true, adds schemas.yml to micronaut config files |
+| schemas.config | object | `{"bank-account": { "id": "UmZ25DANwS6ngGWB4ye4tN:2:BankAccount:0.1", "label": "Bank Account", "defaultAttributeName": "iban", "restrictions": [{"issuerDid": "did:sov:iil:UmZ25DANwS6ngGWB4ye4tN","label": "Demo Bank"}]},"commercial-register": {"id": "R6WR6n7CQVDjvvmwofHK6S:2:commercialregister:0.1", "label": "Commercial Register", "defaultAttributeName": "companyName", "restrictions": [{ "issuerDid": "did:sov:iil:R6WR6n7CQVDjvvmwofHK6S", "label": "Commercial Register" }]}}` | configuration data for schemas to load, stored in ConfigMap as schemas.yml, mounted into bpa deployment |
 
 ## Chart dependencies
 | Repository | Name | Version |

--- a/charts/bpa/templates/_helpers.tpl
+++ b/charts/bpa/templates/_helpers.tpl
@@ -314,3 +314,19 @@ volumeMounts:
   readOnly: true
 {{- end -}}
 {{- end -}}
+
+{{- define "bpa.openshift.route.tls" -}}
+{{- if (.Values.bpa.openshift.route.tls.enabled) -}}
+tls:
+  insecureEdgeTerminationPolicy: {{ .Values.bpa.openshift.route.tls.insecureEdgeTerminationPolicy }}
+  termination: {{ .Values.bpa.openshift.route.tls.termination }}
+{{- end -}}
+{{- end -}}
+
+{{- define "acapy.openshift.route.tls" -}}
+{{- if (.Values.acapy.openshift.route.tls.enabled) -}}
+tls:
+  insecureEdgeTerminationPolicy: {{ .Values.acapy.openshift.route.tls.insecureEdgeTerminationPolicy }}
+  termination: {{ .Values.acapy.openshift.route.tls.termination }}
+{{- end -}}
+{{- end -}}

--- a/charts/bpa/templates/_helpers.tpl
+++ b/charts/bpa/templates/_helpers.tpl
@@ -227,3 +227,90 @@ Create environment variables for database configuration.
   value: {{ .Values.global.persistence.dbName | quote }}
 {{- end }}
 {{- end -}}
+
+
+{{/*
+Return JAVA_OPTS -Dmicronaut.config.files
+*/}}
+{{- define "bpa.config.files" -}}
+{{- if .Values.keycloak.enabled -}}
+    classpath:application.yml,classpath:security-keycloak.yml
+{{- else -}}
+    classpath:application.yml
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return a configuration map value for imprint  and privacy policy urls
+*/}}
+{{- define "bpa.imprint.and.privacy.url" -}}
+{{- if (and .Values.bpa.config.imprint.url .Values.bpa.config.privacy.policy.url) -}}
+   {{- printf "BPA_IMPRINT_URL: %s" (.Values.bpa.config.imprint.url) | indent 2 -}}
+   {{- printf "BPA_PRIVACY_POLICY_URL: %s" (.Values.bpa.config.privacy.policy.url) | nindent 2 -}}
+{{ else if .Values.bpa.config.imprint.url }}
+   {{- printf "BPA_IMPRINT_URL: %s" (.Values.bpa.config.imprint.url) | indent 2 -}}
+{{ else if .Values.bpa.config.privacy.policy.url }}
+   {{- printf "BPA_PRIVACY_POLICY_URL: %s" (.Values.bpa.config.privacy.policy.url) | indent 2 -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+If Keycloak is enabled, add the client id and secret from the keycloak secret to bpa env
+*/}}
+{{- define "bpa.keycloak.secret.env.vars" -}}
+{{- if (.Values.keycloak.enabled) -}}
+- name: BPA_KEYCLOAK_CLIENT_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ template "global.fullname" . }}-keycloak
+      key: clientSecret
+{{- end -}}
+{{- end -}}
+
+{{/*
+If Keycloak is enabled, mount the keycloak config map as env vars
+*/}}
+{{- define "bpa.keycloak.configmap.env.vars" -}}
+{{- if (.Values.keycloak.enabled) -}}
+envFrom:
+  - configMapRef:
+      name: {{ template "bpa.fullname" . }}-keycloak
+{{- end -}}
+{{- end -}}
+
+{{/*
+Mount the application config map as env vars
+*/}}
+{{- define "bpa.application.configmap.env.vars" -}}
+envFrom:
+  - configMapRef:
+      name: {{ template "bpa.fullname" . }}
+{{- end -}}
+
+{{/*
+If schemas is enabled, create a volume for the config map
+*/}}
+{{- define "bpa.schemas.volume" -}}
+{{- if (.Values.schemas.enabled) -}}
+volumes:
+  - name: config
+    configMap:
+      name: {{ template "bpa.fullname" . }}-schemas
+      items:
+      - key: "schemas.yaml"
+        path: "schemas.yml"
+{{- end -}}
+{{- end -}}
+
+{{/*
+If schemas is enabled, create a volume mount for the config map
+*/}}
+{{- define "bpa.schemas.volume.mount" -}}
+{{- if (.Values.schemas.enabled) -}}
+volumeMounts:
+- name: config
+  mountPath: "/home/indy/schemas.yml"
+  subPath: "schemas.yml"
+  readOnly: true
+{{- end -}}
+{{- end -}}

--- a/charts/bpa/templates/acapy_configmap.yaml
+++ b/charts/bpa/templates/acapy_configmap.yaml
@@ -6,21 +6,21 @@ metadata:
     {{- include "acapy.labels" . | nindent 4 }}
 data:
   acapy-static-args.yaml: |
-    auto-accept-invites: true
-    auto-accept-requests: true
-    auto-respond-messages: true
-    auto-respond-credential-proposal: true
-    auto-respond-credential-offer: true
-    auto-respond-credential-request: true
-    auto-respond-presentation-proposal: true
-    auto-respond-presentation-request: true
-    auto-store-credential: true
-    auto-verify-presentation: true
-    auto-ping-connection: true
-    auto-provision: true
-    monitor-ping: true
-    public-invites: true
+    auto-accept-invites: {{ .Values.acapy.staticArgs.autoAcceptInvites }}
+    auto-accept-requests: {{ .Values.acapy.staticArgs.autoAcceptRequests }}
+    auto-respond-messages: {{ .Values.acapy.staticArgs.autoRespondMessages }}
+    auto-respond-credential-proposal: {{ .Values.acapy.staticArgs.autoRespondCredentialProposal }}
+    auto-respond-credential-offer: {{ .Values.acapy.staticArgs.autoRespondCredentialOffer }}
+    auto-respond-credential-request: {{ .Values.acapy.staticArgs.autoRespondCredentialRequest }}
+    auto-respond-presentation-proposal: {{ .Values.acapy.staticArgs.autoRespondPresentationProposal }}
+    auto-respond-presentation-request: {{ .Values.acapy.staticArgs.autoRespondPresentationRequest }}
+    auto-store-credential: {{ .Values.acapy.staticArgs.autoStoreCredential }}
+    auto-verify-presentation: {{ .Values.acapy.staticArgs.autoVerifyPresentation }}
+    auto-ping-connection: {{ .Values.acapy.staticArgs.autoPingConnection }}
+    auto-provision: {{ .Values.acapy.staticArgs.autoProvision }}
+    monitor-ping: {{ .Values.acapy.staticArgs.monitorPing }}
+    public-invites: {{ .Values.acapy.staticArgs.publicInvites }}
     plugin: 'aries_cloudagent.messaging.jsonld'
     outbound-transport: http
     wallet-type: 'indy'
-    log-level: info
+    log-level: {{ .Values.acapy.staticArgs.logLevel }}

--- a/charts/bpa/templates/acapy_deployment.yaml
+++ b/charts/bpa/templates/acapy_deployment.yaml
@@ -33,10 +33,10 @@ spec:
            "-c",
            "curl -d '{\"seed\":\"$(WALLET_SEED)\", \"role\":\"TRUST_ANCHOR\", \"alias\":\"{{ include "bpa.fullname" . }}\"}' -X POST {{ .Values.bpa.config.ledger.browser }}/register; \
            sleep 15; \
-           aca-py start \     
+           aca-py start \
            --auto-provision \
-           --arg-file acapy-static-args.yml \   
-           --inbound-transport http '0.0.0.0' {{ .Values.acapy.service.httpPort }} \ 
+           --arg-file acapy-static-args.yml \
+           --inbound-transport http '0.0.0.0' {{ .Values.acapy.service.httpPort }} \
            --webhook-url http://{{ include "bpa.fullname" . }}:{{ .Values.bpa.service.port }}/log \
            --genesis-url '{{ .Values.bpa.config.ledger.browser }}/genesis' \
            --endpoint https://{{ include "acapy.host" . }} \
@@ -44,7 +44,7 @@ spec:
            --wallet-name 'mywallet' \
            --wallet-key '123' \
            --wallet-storage-config '{\"url\":\"{{ include "global.postgresql.fullname" . }}:{{ .Values.postgresql.service.port }}\",\"max_connections\":5}' \
-           --wallet-storage-creds '{\"account\":\"{{ .Values.postgresql.postgresqlUsername }}\",\"password\":\"$(POSTGRES_PASSWORD)\",\"admin_account\":\"{{ .Values.postgresql.postgresqlUsername }}\",\"admin_password\":\"$(POSTGRES_PASSWORD)\"}' \ 
+           --wallet-storage-creds '{\"account\":\"{{ .Values.postgresql.postgresqlUsername }}\",\"password\":\"$(POSTGRES_PASSWORD)\",\"admin_account\":\"{{ .Values.postgresql.postgresqlUsername }}\",\"admin_password\":\"$(POSTGRES_PASSWORD)\"}' \
            --seed \"$(WALLET_SEED)\" \
            --admin '0.0.0.0' {{ .Values.acapy.service.adminPort }} \
            --admin-insecure-mode \
@@ -62,29 +62,29 @@ spec:
               protocol: TCP
             - name: admin
               containerPort: 8031
-              protocol: TCP              
-          env:   
+              protocol: TCP
+          env:
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "global.postgresql.fullname" . }}
-                  key: postgresql-password         
+                  key: postgresql-password
             - name: WALLET_SEED
               valueFrom:
                 secretKeyRef:
                   name: {{ template "acapy.fullname" . }}
-                  key: seed 
+                  key: seed
           livenessProbe:
             httpGet:
-              path: /status/live 
+              path: /status/live
               port: 8031
-            initialDelaySeconds: 15
-            periodSeconds: 3        
+            initialDelaySeconds: 45
+            periodSeconds: 3
           volumeMounts:
           - name: config
             mountPath: "/home/indy/acapy-static-args.yml"
             subPath: "acapy-static-args.yml"
-            readOnly: true        
+            readOnly: true
           resources:
             {{- toYaml .Values.acapy.resources | nindent 12 }}
       volumes:
@@ -93,7 +93,7 @@ spec:
             name: {{ include "acapy.fullname" . }}
             items:
             - key: "acapy-static-args.yaml"
-              path: "acapy-static-args.yml"              
+              path: "acapy-static-args.yml"
       {{- with .Values.acapy.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/bpa/templates/acapy_route.yaml
+++ b/charts/bpa/templates/acapy_route.yaml
@@ -4,6 +4,8 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: {{ include "acapy.fullname" . }}
+  annotations:
+    haproxy.router.openshift.io/timeout: {{ .Values.acapy.openshift.route.timeout }}
   labels:
     {{- include "acapy.labels" . | nindent 4 }}
 spec:

--- a/charts/bpa/templates/acapy_route.yaml
+++ b/charts/bpa/templates/acapy_route.yaml
@@ -1,0 +1,20 @@
+{{- if (and .Values.acapy.openshift.route.enabled (not .Values.acapy.ingress.enabled)) -}}
+{{- $fullName := include "acapy.fullname" . -}}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "acapy.fullname" . }}
+  labels:
+    {{- include "acapy.labels" . | nindent 4 }}
+spec:
+  host: {{ include "acapy.host" . | quote }}
+  path: {{ .Values.acapy.openshift.route.path }}
+  to:
+    kind: Service
+    name: {{ $fullName }}
+    weight: 100
+  port:
+    targetPort: {{ .Values.acapy.openshift.route.targetPort }}
+  wildcardPolicy: {{ .Values.acapy.openshift.route.wildcardPolicy }}
+{{ include "acapy.openshift.route.tls" . | indent 2}}
+{{- end }}

--- a/charts/bpa/templates/bpa_configmap.yaml
+++ b/charts/bpa/templates/bpa_configmap.yaml
@@ -1,5 +1,7 @@
 {{- $acapyIngressHost := include "acapy.host" . -}}
 {{- $bpaIngressHost := include "bpa.host" . -}}
+{{- $acapyUrl := (printf "http://%s:%g" (include "acapy.fullname" .) (.Values.acapy.service.adminPort)) -}}
+{{- $acapyEndpoint := (printf "https://%s" ($acapyIngressHost)) -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,17 +9,20 @@ metadata:
   labels:
     {{- include "bpa.labels" . | nindent 4 }}
 data:
-  application.yaml: |-  
-    bpa:           
-{{ toYaml .Values.bpa.config | indent 6 }}   
-      acapy:
-        url: http://{{ include "acapy.fullname" . }}:{{ .Values.acapy.service.adminPort }} 
-        apiKey: {{ .Values.acapy.adminURLApiKey }}
-        endpoint: https://{{ $acapyIngressHost }}
-      pg:
-        url: jdbc:postgresql://{{ include "global.postgresql.fullname" . }}/{{ .Values.postgresql.postgresqlUsername }}
-        username: {{ .Values.postgresql.postgresqlUsername }}
-      host: {{ $bpaIngressHost }}
-      micronaut:
-        security:
-          enabled: {{ .Values.bpa.config.security.enabled }}
+  AGENT_NAME: {{ .Values.bpa.config.name | quote }}
+  ACAPY_URL: {{ $acapyUrl | quote }}
+  ACAPY_ENDPOINT: {{ $acapyEndpoint | quote }}
+  ACAPY_API_KEY: {{ .Values.acapy.adminURLApiKey | quote }}
+  POSTGRESQL_HOST: {{ include "global.postgresql.fullname" . | quote }}
+  POSTGRESQL_USER: {{ .Values.postgresql.postgresqlUsername | quote }}
+  BPA_SECURITY_ENABLED: {{ .Values.bpa.config.security.enabled | quote }}
+  BPA_RESOLVER_URL: {{ .Values.bpa.config.resolver.url | quote }}
+  BPA_LEDGER_BROWSER: {{ .Values.bpa.config.ledger.browser | quote }}
+  BPA_HOST: {{ $bpaIngressHost | quote }}
+  BPA_SCHEME: {{ .Values.bpa.config.scheme | quote }}
+  BPA_WEB_MODE: {{ .Values.bpa.config.web.only | quote }}
+  BPA_DID_PREFIX: {{ .Values.bpa.config.did.prefix | quote }}
+  BPA_BOOTSTRAP_UN: {{ .Values.bpa.config.bootstrap.username | quote }}
+  BPA_BOOTSTRAP_PW: {{ .Values.bpa.config.bootstrap.password | quote }}
+  BPA_CREDDEF_REVOCATION_REGISTRY_SIZE: {{ .Values.bpa.config.creddef.revocationRegistrySize | quote }}
+{{ include "bpa.imprint.and.privacy.url" . }}

--- a/charts/bpa/templates/bpa_configmap_keycloak.yaml
+++ b/charts/bpa/templates/bpa_configmap_keycloak.yaml
@@ -1,0 +1,16 @@
+{{- if (.Values.keycloak.enabled) -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "bpa.fullname" . }}-keycloak
+  labels:
+    {{- include "bpa.labels" . | nindent 4 }}
+data:
+  BPA_KEYCLOAK_ROLES_NAME: {{ .Values.keycloak.config.rolesName | quote }}
+  BPA_KEYCLOAK_NAME_KEY: {{ .Values.keycloak.config.nameKey | quote }}
+  BPA_KEYCLOAK_REDIRECT_URI: {{ .Values.keycloak.config.redirectUri | quote }}
+  BPA_KEYCLOAK_SCOPES: {{ .Values.keycloak.config.scopes | quote }}
+  BPA_KEYCLOAK_ISSUER: {{ .Values.keycloak.config.issuer | quote }}
+  BPA_KEYCLOAK_ENDSESSION_URL: {{ .Values.keycloak.config.endsessionUrl | quote }}
+  BPA_KEYCLOAK_CLIENT_ID: {{ .Values.keycloak.clientId | quote }}
+{{- end -}}

--- a/charts/bpa/templates/bpa_configmap_schemas.yaml
+++ b/charts/bpa/templates/bpa_configmap_schemas.yaml
@@ -1,0 +1,13 @@
+{{- if (.Values.schemas.enabled) -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "bpa.fullname" . }}-schemas
+  labels:
+    {{- include "bpa.labels" . | nindent 4 }}
+data:
+  schemas.yaml: |-
+    bpa:
+      schemas:
+{{ toYaml .Values.schemas.config | indent 8 }}
+{{- end -}}

--- a/charts/bpa/templates/bpa_deployment.yaml
+++ b/charts/bpa/templates/bpa_deployment.yaml
@@ -33,18 +33,24 @@ spec:
           ports:
             - name: http
               containerPort: 8080
-              protocol: TCP              
-          env:                        
+              protocol: TCP
+          env:
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "global.postgresql.fullname" . }}
-                  key: postgresql-password          
-            - name: JAVA_OPTS 
+                  key: postgresql-password
+            {{- include "bpa.keycloak.secret.env.vars" . | nindent 12}}
+            - name: JAVA_OPTS
               value: |
-                -Dbpa.pg.password=$(POSTGRES_PASSWORD)                                                            
+                -Dbpa.pg.password=$(POSTGRES_PASSWORD)
+                -Dmicronaut.config.files={{ include "bpa.config.files" . }}
+            {{- include "bpa.application.configmap.env.vars" . | nindent 10}}
+            {{- include "bpa.keycloak.configmap.env.vars" . | nindent 10}}
+          {{- include "bpa.schemas.volume.mount" . | nindent 10}}
           resources:
             {{- toYaml .Values.bpa.resources | nindent 12 }}
+          {{- include "bpa.schemas.volume" . | nindent 6}}
       {{- with .Values.bpa.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/bpa/templates/bpa_route.yaml
+++ b/charts/bpa/templates/bpa_route.yaml
@@ -1,0 +1,20 @@
+{{- if (and .Values.bpa.openshift.route.enabled (not .Values.bpa.ingress.enabled)) -}}
+{{- $fullName := include "bpa.fullname" . -}}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "bpa.fullname" . }}
+  labels:
+    {{- include "bpa.labels" . | nindent 4 }}
+spec:
+  host: {{ include "bpa.host" . | quote }}
+  path: {{ .Values.bpa.openshift.route.path }}
+  to:
+    kind: Service
+    name: {{ $fullName }}
+    weight: 100
+  port:
+    targetPort: {{ .Values.bpa.openshift.route.targetPort }}
+  wildcardPolicy: {{ .Values.bpa.openshift.route.wildcardPolicy }}
+{{ include "bpa.openshift.route.tls" . | indent 2}}
+{{- end }}

--- a/charts/bpa/templates/bpa_route.yaml
+++ b/charts/bpa/templates/bpa_route.yaml
@@ -4,6 +4,8 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: {{ include "bpa.fullname" . }}
+  annotations:
+    haproxy.router.openshift.io/timeout: {{ .Values.bpa.openshift.route.timeout }}
   labels:
     {{- include "bpa.labels" . | nindent 4 }}
 spec:

--- a/charts/bpa/templates/bpa_secret_keycloak.yaml
+++ b/charts/bpa/templates/bpa_secret_keycloak.yaml
@@ -1,0 +1,14 @@
+{{- if (.Values.keycloak.enabled) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "global.fullname" . }}-keycloak
+  labels:
+    app: {{ template "global.name" . }}
+    chart: {{ template "global.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+type: Opaque
+data:
+  clientSecret: {{ .Values.keycloak.clientSecret | b64enc | quote }}
+{{- end -}}

--- a/charts/bpa/values.schema.json
+++ b/charts/bpa/values.schema.json
@@ -12,16 +12,7 @@
                     "type": "object"
                 },
                 "agentName": {
-                    "type": "string",
-                    "description": "Agent name. It's helpful to set it in the as <DID>:<Human readable label>, e.g. did:sov:idu:XnEKP3WieQhNP7ugjV5r36:mybpa",
-                    "form": true
-                },
-                "agentSeed": {
-                    "type": "string",
-                    "description": "The agent seed. Will be generated if not defined here.",
-                    "minLength": 32,
-                    "maxLength": 32,
-                    "form": true
+                    "type": "string"
                 },
                 "fullnameOverride": {
                     "type": "string"
@@ -66,6 +57,45 @@
                 "nodeSelector": {
                     "type": "object"
                 },
+                "openshift": {
+                    "type": "object",
+                    "properties": {
+                        "route": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "path": {
+                                    "type": "string"
+                                },
+                                "targetPort": {
+                                    "type": "string"
+                                },
+                                "timeout": {
+                                    "type": "string"
+                                },
+                                "tls": {
+                                    "type": "object",
+                                    "properties": {
+                                        "enabled": {
+                                            "type": "boolean"
+                                        },
+                                        "insecureEdgeTerminationPolicy": {
+                                            "type": "string"
+                                        },
+                                        "termination": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "wildcardPolicy": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
                 "podAnnotations": {
                     "type": "object"
                 },
@@ -100,6 +130,56 @@
                         }
                     }
                 },
+                "staticArgs": {
+                    "type": "object",
+                    "properties": {
+                        "autoAcceptInvites": {
+                            "type": "boolean"
+                        },
+                        "autoAcceptRequests": {
+                            "type": "boolean"
+                        },
+                        "autoPingConnection": {
+                            "type": "boolean"
+                        },
+                        "autoProvision": {
+                            "type": "boolean"
+                        },
+                        "autoRespondCredentialOffer": {
+                            "type": "boolean"
+                        },
+                        "autoRespondCredentialProposal": {
+                            "type": "boolean"
+                        },
+                        "autoRespondCredentialRequest": {
+                            "type": "boolean"
+                        },
+                        "autoRespondMessages": {
+                            "type": "boolean"
+                        },
+                        "autoRespondPresentationProposal": {
+                            "type": "boolean"
+                        },
+                        "autoRespondPresentationRequest": {
+                            "type": "boolean"
+                        },
+                        "autoStoreCredential": {
+                            "type": "boolean"
+                        },
+                        "autoVerifyPresentation": {
+                            "type": "boolean"
+                        },
+                        "logLevel": {
+                            "type": "string"
+                        },
+                        "monitorPing": {
+                            "type": "boolean"
+                        },
+                        "publicInvites": {
+                            "type": "boolean"
+                        }
+                    }
+                },
                 "tolerations": {
                     "type": "array"
                 }
@@ -116,29 +196,36 @@
                     "properties": {
                         "bootstrap": {
                             "type": "object",
-                            "description": "The administrator credentials.",
                             "properties": {
                                 "password": {
-                                    "type": "string",
-                                    "form": true
+                                    "type": "string"
                                 },
                                 "username": {
-                                    "type": "string",
-                                    "form": true
+                                    "type": "string"
                                 }
-                            },
-                            "form": true
-                        },
-                        "name": {
-                            "description": "Name shown in the frontend.",
-                            "type": "string",
-                            "form": true
+                            }
                         },
                         "creddef": {
                             "type": "object",
                             "properties": {
                                 "revocationRegistrySize": {
                                     "type": "integer"
+                                }
+                            }
+                        },
+                        "did": {
+                            "type": "object",
+                            "properties": {
+                                "prefix": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "imprint": {
+                            "type": "object",
+                            "properties": {
+                                "url": {
+                                    "type": "null"
                                 }
                             }
                         },
@@ -150,6 +237,22 @@
                                 }
                             }
                         },
+                        "name": {
+                            "type": "string"
+                        },
+                        "privacy": {
+                            "type": "object",
+                            "properties": {
+                                "policy": {
+                                    "type": "object",
+                                    "properties": {
+                                        "url": {
+                                            "type": "null"
+                                        }
+                                    }
+                                }
+                            }
+                        },
                         "resolver": {
                             "type": "object",
                             "properties": {
@@ -157,6 +260,9 @@
                                     "type": "string"
                                 }
                             }
+                        },
+                        "scheme": {
+                            "type": "string"
                         },
                         "security": {
                             "type": "object",
@@ -212,6 +318,45 @@
                 },
                 "nodeSelector": {
                     "type": "object"
+                },
+                "openshift": {
+                    "type": "object",
+                    "properties": {
+                        "route": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "path": {
+                                    "type": "string"
+                                },
+                                "targetPort": {
+                                    "type": "string"
+                                },
+                                "timeout": {
+                                    "type": "string"
+                                },
+                                "tls": {
+                                    "type": "object",
+                                    "properties": {
+                                        "enabled": {
+                                            "type": "boolean"
+                                        },
+                                        "insecureEdgeTerminationPolicy": {
+                                            "type": "string"
+                                        },
+                                        "termination": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "wildcardPolicy": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
                 },
                 "podAnnotations": {
                     "type": "object"
@@ -277,9 +422,54 @@
                 }
             }
         },
+        "keycloak": {
+            "type": "object",
+            "properties": {
+                "clientId": {
+                    "type": "string"
+                },
+                "clientSecret": {
+                    "type": "string"
+                },
+                "config": {
+                    "type": "object",
+                    "properties": {
+                        "endsessionUrl": {
+                            "type": "string"
+                        },
+                        "issuer": {
+                            "type": "string"
+                        },
+                        "nameKey": {
+                            "type": "string"
+                        },
+                        "redirectUri": {
+                            "type": "string"
+                        },
+                        "rolesName": {
+                            "type": "string"
+                        },
+                        "scopes": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
         "postgresql": {
             "type": "object",
             "properties": {
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        }
+                    }
+                },
                 "image": {
                     "type": "object",
                     "properties": {
@@ -305,6 +495,14 @@
                 "postgresqlUsername": {
                     "type": "string"
                 },
+                "securityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        }
+                    }
+                },
                 "service": {
                     "type": "object",
                     "properties": {
@@ -312,6 +510,75 @@
                             "type": "integer"
                         }
                     }
+                }
+            }
+        },
+        "schemas": {
+            "type": "object",
+            "properties": {
+                "config": {
+                    "type": "object",
+                    "properties": {
+                        "bank-account": {
+                            "type": "object",
+                            "properties": {
+                                "defaultAttributeName": {
+                                    "type": "string"
+                                },
+                                "id": {
+                                    "type": "string"
+                                },
+                                "label": {
+                                    "type": "string"
+                                },
+                                "restrictions": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "issuerDid": {
+                                                "type": "string"
+                                            },
+                                            "label": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "commercial-register": {
+                            "type": "object",
+                            "properties": {
+                                "defaultAttributeName": {
+                                    "type": "string"
+                                },
+                                "id": {
+                                    "type": "string"
+                                },
+                                "label": {
+                                    "type": "string"
+                                },
+                                "restrictions": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "issuerDid": {
+                                                "type": "string"
+                                            },
+                                            "label": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "enabled": {
+                    "type": "boolean"
                 }
             }
         }

--- a/charts/bpa/values.yaml
+++ b/charts/bpa/values.yaml
@@ -90,6 +90,17 @@ bpa:
     #    hosts:
     #      - my-bpa.local
 
+  openshift:
+    route:
+      enabled: false
+      path: "/"
+      targetPort: http
+      tls:
+        enabled: true
+        insecureEdgeTerminationPolicy: None
+        termination: edge
+      wildcardPolicy: None
+
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
@@ -111,19 +122,19 @@ bpa:
 keycloak:
   enabled: false
 
-  clientId: mykeycloak-client
-  clientSecret: boahlalhalhjalsdfhasdfh
+  clientId: <your keycloak client id>
+  clientSecret: <your keycloak client secret>
 
   config:
     rolesName: roles
     nameKey: preferred_username
-    redirectUri: http://localhost:48080/logout
+    redirectUri: "${bpa.scheme}://${bpa.host}/logout"
     scopes: openid
-    issuer: https://dev.oidc.gov.bc.ca/auth/realms/digitaltrust
-    endsessionUrl: https://dev.oidc.gov.bc.ca/auth/realms/digitaltrust/protocol/openid-connect/logout
+    issuer: <your keycloak realm issuer url>
+    endsessionUrl: <your keycloak realm end session url>
 
 schemas:
-  enabled: false
+  enabled: true
   config:
     bank-account:
       id: "UmZ25DANwS6ngGWB4ye4tN:2:BankAccount:0.1"
@@ -194,6 +205,17 @@ acapy:
     #  - secretName: my-acapy-tls
     #    hosts:
     #      - my-acapy.local
+
+  openshift:
+    route:
+      enabled: false
+      path: "/"
+      targetPort: http
+      tls:
+        enabled: true
+        insecureEdgeTerminationPolicy: None
+        termination: edge
+      wildcardPolicy: None
 
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/bpa/values.yaml
+++ b/charts/bpa/values.yaml
@@ -137,18 +137,18 @@ schemas:
   enabled: true
   config:
     bank-account:
-      id: "UmZ25DANwS6ngGWB4ye4tN:2:BankAccount:0.1"
+      id: "M6Mbe3qx7vB4wpZF4sBRjt:2:bank_account:1.0"
       label: "Bank Account"
       defaultAttributeName: "iban"
       restrictions:
-        - issuerDid: "did:sov:iil:UmZ25DANwS6ngGWB4ye4tN"
+        - issuerDid: "${bpa.did.prefix}M6Mbe3qx7vB4wpZF4sBRjt"
           label: "Demo Bank"
     commercial-register:
-      id: "R6WR6n7CQVDjvvmwofHK6S:2:commercialregister:0.1"
+      id: "5mwQSWnRePrZ3oF67C4KqD:2:commercialregister:1.0"
       label: "Commercial Register"
       defaultAttributeName: "companyName"
       restrictions:
-        - issuerDid: "did:sov:iil:R6WR6n7CQVDjvvmwofHK6S"
+        - issuerDid: "${bpa.did.prefix}5mwQSWnRePrZ3oF67C4KqD"
           label: "Commercial Register"
 
 acapy:

--- a/charts/bpa/values.yaml
+++ b/charts/bpa/values.yaml
@@ -16,7 +16,7 @@ global:
 
 bpa:
   name: bpacore
- 
+
   image:
     repository: ghcr.io/hyperledger-labs/business-partner-agent
     pullPolicy: IfNotPresent
@@ -30,47 +30,35 @@ bpa:
     annotations: {}
     # The name of the service account to use.
     # If not set and create is true, a name is generated using the fullname template
-    name: ""  
+    name: ""
 
   # -- application config (remark: all new configuration values will sit here, the other ones can be migrated step by step)
-  config: 
+  config:
     security:
-      enabled: true  
+      enabled: true
     bootstrap:
       username: admin
-      password: changeme      
+      password: changeme
     resolver:
       url: https://resolver.stage.economyofthings.io
     ledger:
       browser: https://indy-test.bosch-digital.de
     name: Business Partner Agent
+    scheme: https
     web:
-      only: false 
+      only: false
+    did:
+      prefix: "did:sov:iil:"
     creddef:
-      revocationRegistrySize: 3000 
-    #schemas:
-    #  bank-account:
-    #    id: "UmZ25DANwS6ngGWB4ye4tN:2:BankAccount:0.1"
-    #    label: "Bank Account"
-    #    defaultAttributeName: "iban"
-    #    restrictions:
-    #      - issuerDid: "did:sov:iil:UmZ25DANwS6ngGWB4ye4tN"
-    #        label: "Demo Bank"
-    #  commercial-register:
-    #    id: "R6WR6n7CQVDjvvmwofHK6S:2:commercialregister:0.1"
-    #    label: "Commercial Register"
-    #    defaultAttributeName: "companyName"
-    #    restrictions:
-    #      - issuerDid: "did:sov:iil:R6WR6n7CQVDjvvmwofHK6S"
-    #        label: "Commercial Register"
-    #imprint:
-    #  url: 
-    #privacy:
-    #  policy:
-    #    url:   
+      revocationRegistrySize: 3000
+    imprint:
+      url:
+    privacy:
+      policy:
+        url:
 
   imagePullSecrets: []
- 
+
   podAnnotations: {}
 
   podSecurityContext: {}
@@ -94,7 +82,7 @@ bpa:
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
     # Uncomment this to define your own hosts and override global.ingressSuffix
-    # hosts: 
+    # hosts:
     #     host:
     #     paths: ['/']
     tls: []
@@ -120,6 +108,38 @@ bpa:
 
   affinity: {}
 
+keycloak:
+  enabled: false
+
+  clientId: mykeycloak-client
+  clientSecret: boahlalhalhjalsdfhasdfh
+
+  config:
+    rolesName: roles
+    nameKey: preferred_username
+    redirectUri: http://localhost:48080/logout
+    scopes: openid
+    issuer: https://dev.oidc.gov.bc.ca/auth/realms/digitaltrust
+    endsessionUrl: https://dev.oidc.gov.bc.ca/auth/realms/digitaltrust/protocol/openid-connect/logout
+
+schemas:
+  enabled: false
+  config:
+    bank-account:
+      id: "UmZ25DANwS6ngGWB4ye4tN:2:BankAccount:0.1"
+      label: "Bank Account"
+      defaultAttributeName: "iban"
+      restrictions:
+        - issuerDid: "did:sov:iil:UmZ25DANwS6ngGWB4ye4tN"
+          label: "Demo Bank"
+    commercial-register:
+      id: "R6WR6n7CQVDjvvmwofHK6S:2:commercialregister:0.1"
+      label: "Commercial Register"
+      defaultAttributeName: "companyName"
+      restrictions:
+        - issuerDid: "did:sov:iil:R6WR6n7CQVDjvvmwofHK6S"
+          label: "Commercial Register"
+
 acapy:
   name: acapy
 
@@ -138,7 +158,7 @@ acapy:
 
   readOnlyMode: false
 
-  imagePullSecrets: [] 
+  imagePullSecrets: []
   nameOverride: ""
   fullnameOverride: ""
 
@@ -167,7 +187,7 @@ acapy:
       # kubernetes.io/tls-acme: "true"
 
     # Uncomment this to define your own hosts and override global.ingressSuffix
-    # hosts: 
+    # hosts:
     #     host:
     #     paths: ['/']
     tls: []
@@ -193,6 +213,23 @@ acapy:
 
   affinity: {}
 
+  staticArgs:
+    autoAcceptInvites: true
+    autoAcceptRequests: true
+    autoRespondMessages: true
+    autoRespondCredentialProposal: true
+    autoRespondCredentialOffer: true
+    autoRespondCredentialRequest: true
+    autoRespondPresentationProposal: true
+    autoRespondPresentationRequest: true
+    autoStoreCredential: true
+    autoVerifyPresentation: true
+    autoPingConnection: true
+    autoProvision: true
+    monitorPing: true
+    publicInvites: true
+    logLevel: info
+
 postgresql:
   # --  PostgreSQL service configuration
   service:
@@ -209,8 +246,13 @@ postgresql:
 
   # --  Persistent Volume Storage configuration. ref: https://kubernetes.io/docs/user-guide/persistent-volumes
   persistence:
-    
+
     # -- Enable PostgreSQL persistence using Persistent Volume Claims.
     enabled: false
   image:
     tag: 12
+  # -- add securityContext (fsGroup, runAsUser). These need to be false for Openshift 4
+  securityContext:
+    enabled: true
+  containerSecurityContext:
+    enabled: true

--- a/charts/bpa/values.yaml
+++ b/charts/bpa/values.yaml
@@ -95,6 +95,7 @@ bpa:
       enabled: false
       path: "/"
       targetPort: http
+      timeout: 30s
       tls:
         enabled: true
         insecureEdgeTerminationPolicy: None
@@ -211,6 +212,7 @@ acapy:
       enabled: false
       path: "/"
       targetPort: http
+      timeout: 30s
       tls:
         enabled: true
         insecureEdgeTerminationPolicy: None

--- a/frontend/src/services/interceptors.js
+++ b/frontend/src/services/interceptors.js
@@ -12,10 +12,10 @@ import Vue from 'vue';
 /**
  * @function appAxios
  * Returns an Axios instance with pre-configuration
- * @param {integer} [timeout=10000] Number of milliseconds before timing out the request
+ * @param {number} [timeout=10000] Number of milliseconds before timing out the request
  * @returns {object} An axios instance
  */
-export function appAxios(timeout = 30000) {
+export function appAxios(timeout = 0) {
   const axiosOptions = { timeout: timeout };
   if (Vue.prototype.$config) {
     // any other options we can set here?

--- a/frontend/src/services/interceptors.js
+++ b/frontend/src/services/interceptors.js
@@ -15,7 +15,7 @@ import Vue from 'vue';
  * @param {number} [timeout=10000] Number of milliseconds before timing out the request
  * @returns {object} An axios instance
  */
-export function appAxios(timeout = 0) {
+export function appAxios(timeout = 60000) {
   const axiosOptions = { timeout: timeout };
   if (Vue.prototype.$config) {
     // any other options we can set here?

--- a/frontend/src/services/interceptors.js
+++ b/frontend/src/services/interceptors.js
@@ -15,7 +15,7 @@ import Vue from 'vue';
  * @param {number} [timeout=10000] Number of milliseconds before timing out the request
  * @returns {object} An axios instance
  */
-export function appAxios(timeout = 60000) {
+export function appAxios(timeout = 0) {
   const axiosOptions = { timeout: timeout };
   if (Vue.prototype.$config) {
     // any other options we can set here?

--- a/scripts/.env-example
+++ b/scripts/.env-example
@@ -9,6 +9,7 @@ AGENT_NAME="Business Partner Agent"
 BPA_HOST=localhost
 BPA_PORT=8080
 BPA_SCHEME=https
+BPA_CONFIG_FILES=classpath:application.yml,classpath:schemas.yml
 
 # Security
 BPA_SECURITY_ENABLED=true

--- a/scripts/docker-compose.custom-acapy.yml
+++ b/scripts/docker-compose.custom-acapy.yml
@@ -13,6 +13,7 @@ services:
         -Dbpa.acapy.apiKey=${ACAPY_ADMIN_URL_API_KEY}
         -Dmicronaut.security.enabled=${BPA_SECURITY_ENABLED}
         -Dmicronaut.server.port=${BPA_PORT}
+        -Dmicronaut.config.files=${BPA_CONFIG_FILES}
         -Dbpa.pg.url=jdbc:postgresql://${POSTGRESQL_HOST}/${POSTGRESQL_USER}
         -Dbpa.pg.username=${POSTGRESQL_USER}
         -Dbpa.pg.password=${POSTGRESQL_PASSWORD}

--- a/scripts/docker-compose.dev.yml
+++ b/scripts/docker-compose.dev.yml
@@ -14,6 +14,7 @@ services:
         -Dbpa.acapy.apiKey=${ACAPY_ADMIN_URL_API_KEY}
         -Dmicronaut.security.enabled=${BPA_SECURITY_ENABLED}
         -Dmicronaut.server.port=${BPA_PORT}
+        -Dmicronaut.config.files=${BPA_CONFIG_FILES}
         -Dbpa.pg.url=jdbc:postgresql://${POSTGRESQL_HOST}/${POSTGRESQL_USER}
         -Dbpa.pg.username=${POSTGRESQL_USER}
         -Dbpa.pg.password=${POSTGRESQL_PASSWORD}

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -13,6 +13,7 @@ services:
         -Dbpa.acapy.apiKey=${ACAPY_ADMIN_URL_API_KEY}
         -Dmicronaut.security.enabled=${BPA_SECURITY_ENABLED}
         -Dmicronaut.server.port=${BPA_PORT}
+        -Dmicronaut.config.files=${BPA_CONFIG_FILES}
         -Dbpa.pg.url=jdbc:postgresql://${POSTGRESQL_HOST}/${POSTGRESQL_USER}
         -Dbpa.pg.username=${POSTGRESQL_USER}
         -Dbpa.pg.password=${POSTGRESQL_PASSWORD}

--- a/scripts/local-network/.env-example
+++ b/scripts/local-network/.env-example
@@ -14,6 +14,7 @@ BPA2_PORT=8010
 BPA1_DEBUG_PORT=1044
 
 BPA_SCHEME=http
+BPA_CONFIG_FILES=classpath:application.yml,classpath:schemas.yml
 
 # Security
 BPA_SECURITY_ENABLED=false

--- a/scripts/local-network/docker-compose-linux.yml
+++ b/scripts/local-network/docker-compose-linux.yml
@@ -17,6 +17,7 @@ services:
         -Dmicronaut.security.enabled=${BPA_SECURITY_ENABLED}
         -Dmicronaut.server.port=${BPA1_PORT}
         -Dmicronaut.environments=dev
+        -Dmicronaut.config.files=${BPA_CONFIG_FILES}
         -Dbpa.pg.url=jdbc:postgresql://${POSTGRESQL1_HOST}/${POSTGRESQL_USER}
         -Dbpa.pg.username=${POSTGRESQL_USER}
         -Dbpa.pg.password=${POSTGRESQL_PASSWORD}
@@ -101,6 +102,7 @@ services:
         -Dmicronaut.security.enabled=${BPA_SECURITY_ENABLED}
         -Dmicronaut.server.port=${BPA2_PORT}
         -Dmicronaut.environments=dev
+        -Dmicronaut.config.files=${BPA_CONFIG_FILES}
         -Dbpa.pg.url=jdbc:postgresql://${POSTGRESQL2_HOST}/${POSTGRESQL_USER}
         -Dbpa.pg.username=${POSTGRESQL_USER}
         -Dbpa.pg.password=${POSTGRESQL_PASSWORD}

--- a/scripts/local-network/docker-compose.yml
+++ b/scripts/local-network/docker-compose.yml
@@ -17,6 +17,7 @@ services:
         -Dmicronaut.security.enabled=${BPA_SECURITY_ENABLED}
         -Dmicronaut.server.port=${BPA1_PORT}
         -Dmicronaut.environments=dev
+        -Dmicronaut.config.files=${BPA_CONFIG_FILES}
         -Dbpa.pg.url=jdbc:postgresql://${POSTGRESQL1_HOST}/${POSTGRESQL_USER}
         -Dbpa.pg.username=${POSTGRESQL_USER}
         -Dbpa.pg.password=${POSTGRESQL_PASSWORD}
@@ -101,6 +102,7 @@ services:
         -Dmicronaut.security.enabled=${BPA_SECURITY_ENABLED}
         -Dmicronaut.server.port=${BPA2_PORT}
         -Dmicronaut.environments=dev
+        -Dmicronaut.config.files=${BPA_CONFIG_FILES}
         -Dbpa.pg.url=jdbc:postgresql://${POSTGRESQL2_HOST}/${POSTGRESQL_USER}
         -Dbpa.pg.username=${POSTGRESQL_USER}
         -Dbpa.pg.password=${POSTGRESQL_PASSWORD}


### PR DESCRIPTION
Refactored the helm charts.

I have moved `bpa.schemas` into it's own file, and that will have to be loaded via `-Dmicronaut.config.files=classpath:application.yml,classpath:schemas.yml`. But this allows us to create a ConfigMap that contains only schema information (as yaml) that can be loaded via helm charts (mounted as a volume). Adding schemas to runtime is controlled with the values file: `schemas.enabled=true`.

`application.yml` and `security-keycloak.yml` can be configured with ENV VARS, so the ConfigMaps for application and keycloak are Name/Value pairs and those ConfigMaps are loaded as env vars.  `security-keycloak.yml` is optional and controlled with the values file: `keycloak.enabled=true`.

Added in new templates for creating Openshift routes. These are optional and must be enabled and ingresses disabled. Was having lots of issues getting secured routes created using the ingress templates, this seemed easier.
