### PR TITLE
Adding GLN as another Identifier along side the LEI, DUNS, etc. IDs

### DIFF
--- a/frontend/src/components/OrganizationalProfile.vue
+++ b/frontend/src/components/OrganizationalProfile.vue
@@ -172,7 +172,7 @@ export default {
   },
   data: () => {
     return {
-      identifierTypes: ["LEI", "D-U-N-S", "VAT", "USCC"],
+      identifierTypes: ["LEI", "GLN", "D-U-N-S", "VAT", "USCC"],
       orgTypes: ["Legal Entity", "Business Unit", "Site"],
       intDoc: Object,
     };


### PR DESCRIPTION
Signed-off-by: Sebastian Schmittner <sebastian.schmittner@eecc.de>

I have tested this change by building and running a container using https://github.com/hyperledger-labs/business-partner-agent/blob/master/scripts/docker-compose.dev.yml build. The new GLN appears in the public profile just as the other IDs. Generic handling of the id types in the backend makes this change almost trivial. :+1: