### PR TITLE
Standardize secondary buttons (text, outlined),

### DIFF
--- a/backend/business-partner-agent/src/main/resources/application.yml
+++ b/backend/business-partner-agent/src/main/resources/application.yml
@@ -143,7 +143,16 @@ bpa:
 # This will have all of the alternate layout and themes/colors loaded.
 # To override theme, then set themes.light properties
 # To override favicon, then need favicon.href property
+# buttons are applied against v-bpa-buttons and determined by the color attribute
+#   example: <v-bpa-button color="primary">Primary</v-bpa-button>
 #  ux:
+#    buttons:
+#      primary:
+#        text: false
+#        outlined: false
+#      secondary:
+#        text: true
+#        outlined: true
 #    theme:
 #      dark: false
 #      themes:

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -272,10 +272,7 @@ export default {
         },
         settings: {
           enabled: true,
-          location: {
-            top: true,
-            bottom: false,
-          },
+          location: "top",
         }
       }
     }

--- a/frontend/src/assets/scss/style.scss
+++ b/frontend/src/assets/scss/style.scss
@@ -149,3 +149,11 @@ div {
     }
   }
 }
+
+.v-input__append-inner {
+  > .v-btn {
+    margin-top: -4px;
+    margin-bottom: 4px;
+    margin-right: 4px;
+  }
+}

--- a/frontend/src/assets/scss/style.scss
+++ b/frontend/src/assets/scss/style.scss
@@ -119,10 +119,6 @@ div {
     }
   }
 
-  &.v-btn--disabled {
-    color: #777;
-  }
-
   &.v-btn--outlined {
     &.theme--light {
       border: 2px solid var(--v-primary-base);

--- a/frontend/src/components/AddSchema.vue
+++ b/frontend/src/components/AddSchema.vue
@@ -8,7 +8,7 @@
 <template>
   <v-container>
     <v-card class="mx-auto">
-      <v-card-title class="bg-light"> Add Schema </v-card-title>
+      <v-card-title class="bg-light"> Import Schema </v-card-title>
       <v-card-text>
         <v-list-item>
           <v-list-item-title
@@ -51,11 +51,10 @@
       </v-card-text>
       <v-card-actions>
         <v-layout align-end justify-end>
-          <v-btn color="secondary" text @click="cancel()">Cancel</v-btn>
+          <v-btn color="secondary" text outlined @click="cancel()">Cancel</v-btn>
           <v-btn
             :loading="this.isBusy"
             color="primary"
-            text
             @click="submit()"
             :disabled="fieldsEmpty"
             >Submit</v-btn

--- a/frontend/src/components/AddSchema.vue
+++ b/frontend/src/components/AddSchema.vue
@@ -51,13 +51,13 @@
       </v-card-text>
       <v-card-actions>
         <v-layout align-end justify-end>
-          <v-btn color="secondary" text outlined @click="cancel()">Cancel</v-btn>
-          <v-btn
+          <v-bpa-button color="secondary" @click="cancel()">Cancel</v-bpa-button>
+          <v-bpa-button
             :loading="this.isBusy"
             color="primary"
             @click="submit()"
             :disabled="fieldsEmpty"
-            >Submit</v-btn
+            >Submit</v-bpa-button
           >
         </v-layout>
       </v-card-actions>
@@ -68,10 +68,11 @@
 <script>
 import { EventBus } from "@/main";
 import adminService from "@/services/adminService";
+import VBpaButton from "@/components/BpaButton";
 
 export default {
   name: "AddSchema",
-  components: {},
+  components: {VBpaButton},
   props: {},
   data: () => {
     return {

--- a/frontend/src/components/BpaButton.js
+++ b/frontend/src/components/BpaButton.js
@@ -1,0 +1,93 @@
+/*
+  Copyright (c) 2021 - for information on the respective copyright owner
+see the NOTICE file and/or the repository at
+https://github.com/hyperledger-labs/organizational-agent
+
+  SPDX-License-Identifier: Apache-2.0
+*/
+import {VBtn} from 'vuetify/lib';
+import Routable from "vuetify/es5/mixins/routable/index";
+
+export default {
+  name: 'v-bpa-button',
+  extends: VBtn,
+
+  computed: {
+    // see if we have a loaded configuration override.
+    // we will use the color property to determine our config
+    // ux.buttons.primary or ux.buttons.secondary...
+    getRuntimeConfiguration() {
+      let runtimeConfig = {
+        primary: {
+          text: false,
+          outlined: false,
+        },
+        secondary: {
+          text: true,
+          outlined: false,
+        }
+      }
+      // check for configuration overrides from the server...
+      if (this.$config && this.$config.ux && this.$config.ux.buttons && this.$config.ux.buttons[this.color]) {
+        Object.assign(runtimeConfig[this.color], this.$config.ux.buttons[this.color]);
+      }
+      // return the config for primary or secondary (or return undefined)
+      return runtimeConfig[this.color];
+    },
+    // since we are mutating properties, we have to compute our value and use it wherever VBtn was performing logic with the property
+    _text() {
+      let config = this.getRuntimeConfiguration;
+      if (config) {
+        return config.text;
+      }
+      return this.text;
+    },
+    _outlined() {
+      let config = this.getRuntimeConfiguration;
+      if (config) {
+        return config.outlined;
+      }
+      return this.outlined;
+    },
+    // replace the VBtn classes computation with our new "properties"
+    classes() {
+      return {
+        'v-btn': true,
+        ...Routable.options.computed.classes.call(this),
+        'v-btn--absolute': this.absolute,
+        'v-btn--block': this.block,
+        'v-btn--bottom': this.bottom,
+        'v-btn--disabled': this.disabled,
+        'v-btn--is-elevated': this.isElevated,
+        'v-btn--fab': this.fab,
+        'v-btn--fixed': this.fixed,
+        'v-btn--has-bg': this.hasBg,
+        'v-btn--icon': false,
+        'v-btn--left': this.left,
+        'v-btn--loading': this.loading,
+        'v-btn--outlined': this._outlined,
+        'v-btn--plain': this.plain,
+        'v-btn--right': this.right,
+        'v-btn--round': this.isRound,
+        'v-btn--rounded': this.rounded,
+        'v-btn--router': this.to,
+        'v-btn--text': this._text,
+        'v-btn--tile': this.tile,
+        'v-btn--top': this.top,
+        ...this.themeClasses,
+        ...this.groupClasses,
+        ...this.elevationClasses,
+        ...this.sizeableClasses,
+      }
+    },
+    // replace the VBtn hasBg computation with our new "properties"
+    hasBg() {
+      return !this._text && !this.plain && !this._outlined && !this.icon;
+    },
+    // replace the VBtn isElevated computation with our new "properties"
+    isElevated() {
+      return Boolean(!this.icon && !this._text && !this._outlined && !this.depressed && !this.disabled && !this.plain && (this.elevation == null || Number(this.elevation) > 0));
+    },
+  },
+
+}

--- a/frontend/src/components/CreateSchema.vue
+++ b/frontend/src/components/CreateSchema.vue
@@ -112,11 +112,10 @@
       </v-card-text>
       <v-card-actions>
         <v-layout align-end justify-end>
-          <v-btn color="secondary" text @click="cancel()">Cancel</v-btn>
+          <v-btn color="secondary" text outlined @click="cancel()">Cancel</v-btn>
           <v-btn
             :loading="this.isBusy"
             color="primary"
-            text
             @click="submit()"
             :disabled="fieldsEmpty"
             >Submit</v-btn

--- a/frontend/src/components/CreateSchema.vue
+++ b/frontend/src/components/CreateSchema.vue
@@ -112,13 +112,13 @@
       </v-card-text>
       <v-card-actions>
         <v-layout align-end justify-end>
-          <v-btn color="secondary" text outlined @click="cancel()">Cancel</v-btn>
-          <v-btn
+          <v-bpa-button color="secondary" @click="cancel()">Cancel</v-bpa-button>
+          <v-bpa-button
             :loading="this.isBusy"
             color="primary"
             @click="submit()"
             :disabled="fieldsEmpty"
-            >Submit</v-btn
+            >Submit</v-bpa-button
           >
         </v-layout>
       </v-card-actions>
@@ -129,10 +129,11 @@
 <script>
 import { EventBus } from "@/main";
 import { issuerService } from "@/services";
+import VBpaButton from "@/components/BpaButton";
 
 export default {
   name: "CreateSchema",
-  components: {},
+  components: {VBpaButton},
   props: {},
   data: () => {
     return {

--- a/frontend/src/components/CredExList.vue
+++ b/frontend/src/components/CredExList.vue
@@ -43,7 +43,7 @@
         </v-card-text>
         <v-card-actions>
           <v-spacer></v-spacer>
-          <v-btn color="primary" text @click="dialog = false">Close</v-btn>
+          <v-btn color="primary" @click="dialog = false">Close</v-btn>
         </v-card-actions>
       </v-card>
     </v-dialog>

--- a/frontend/src/components/CredExList.vue
+++ b/frontend/src/components/CredExList.vue
@@ -43,7 +43,7 @@
         </v-card-text>
         <v-card-actions>
           <v-spacer></v-spacer>
-          <v-btn color="primary" @click="dialog = false">Close</v-btn>
+          <v-bpa-button color="primary" @click="dialog = false">Close</v-bpa-button>
         </v-card-actions>
       </v-card>
     </v-dialog>
@@ -51,6 +51,7 @@
 </template>
 <script>
 import Cred from "@/components/Credential.vue";
+import VBpaButton from "@/components/BpaButton";
 
 export default {
   props: {
@@ -111,6 +112,7 @@ export default {
     },
   },
   components: {
+    VBpaButton,
     Cred,
   },
 };

--- a/frontend/src/components/CredentialDefinitions.vue
+++ b/frontend/src/components/CredentialDefinitions.vue
@@ -33,11 +33,10 @@
         <v-btn
           v-if="!entry.id && entry.isEdit"
           :loading="isBusy"
-          color="primary"
-          text
+          icon
           @click="saveItem(entry)"
         >
-          <v-icon>$vuetify.icons.save</v-icon>
+          <v-icon color="primary">$vuetify.icons.save</v-icon>
         </v-btn>
         <v-btn icon v-if="!entry.isEdit" @click="deleteItem(index)">
           <v-icon color="error">$vuetify.icons.delete</v-icon>
@@ -45,7 +44,7 @@
       </v-col>
     </v-row>
     <v-row>
-      <v-btn :disabled="isEdit" color="primary" text @click="addItem"
+      <v-btn :disabled="isEdit" color="secondary" text outlined @click="addItem"
         >Add Credential Definition</v-btn
       >
     </v-row>

--- a/frontend/src/components/CredentialDefinitions.vue
+++ b/frontend/src/components/CredentialDefinitions.vue
@@ -44,8 +44,8 @@
       </v-col>
     </v-row>
     <v-row>
-      <v-btn :disabled="isEdit" color="secondary" text outlined @click="addItem"
-        >Add Credential Definition</v-btn
+      <v-bpa-button :disabled="isEdit" color="secondary" @click="addItem"
+        >Add Credential Definition</v-bpa-button
       >
     </v-row>
   </v-container>
@@ -54,8 +54,10 @@
 <script>
 import { EventBus } from "@/main";
 import issuerService from "@/services/issuerService";
+import VBpaButton from "@/components/BpaButton";
 
 export default {
+  components: {VBpaButton},
   props: {
     schema: {
       type: Object,

--- a/frontend/src/components/IssueCredential.vue
+++ b/frontend/src/components/IssueCredential.vue
@@ -53,11 +53,10 @@
       </v-card-text>
       <v-card-actions>
         <v-layout align-end justify-end>
-          <v-btn color="secondary" text @click="cancel()">Cancel</v-btn>
+          <v-btn color="secondary" text outlined @click="cancel()">Cancel</v-btn>
           <v-btn
             :loading="this.isBusy"
             color="primary"
-            text
             @click="submit()"
             :disabled="submitDisabled"
             >Submit</v-btn

--- a/frontend/src/components/IssueCredential.vue
+++ b/frontend/src/components/IssueCredential.vue
@@ -53,13 +53,13 @@
       </v-card-text>
       <v-card-actions>
         <v-layout align-end justify-end>
-          <v-btn color="secondary" text outlined @click="cancel()">Cancel</v-btn>
-          <v-btn
+          <v-bpa-button color="secondary" @click="cancel()">Cancel</v-bpa-button>
+          <v-bpa-button
             :loading="this.isBusy"
             color="primary"
             @click="submit()"
             :disabled="submitDisabled"
-            >Submit</v-btn
+            >Submit</v-bpa-button
           >
         </v-layout>
       </v-card-actions>
@@ -71,10 +71,11 @@
 import { EventBus } from "@/main";
 import { issuerService, partnerService } from "@/services";
 import * as textUtils from "@/utils/textUtils";
+import VBpaButton from "@/components/BpaButton";
 
 export default {
   name: "IssueCredential",
-  components: {},
+  components: {VBpaButton},
   props: {
     partnerId: String,
     credDefId: String,

--- a/frontend/src/components/ManageSchema.vue
+++ b/frontend/src/components/ManageSchema.vue
@@ -89,7 +89,7 @@
 
       <v-card-actions>
         <v-layout align-end justify-end>
-          <v-btn color="primary" @click="closed">Close</v-btn>
+          <v-bpa-button color="primary" @click="closed">Close</v-bpa-button>
         </v-layout>
       </v-card-actions>
     </v-card>
@@ -101,6 +101,7 @@ import { EventBus } from "@/main";
 import { adminService } from "@/services";
 import TrustedIssuers from "@/components/TrustedIssuers";
 import CredentialDefinitions from "@/components/CredentialDefinitions";
+import VBpaButton from "@/components/BpaButton";
 export default {
   name: "ManageSchema",
   props: {
@@ -119,6 +120,7 @@ export default {
     },
   },
   components: {
+    VBpaButton,
     CredentialDefinitions,
     TrustedIssuers,
   },

--- a/frontend/src/components/ManageSchema.vue
+++ b/frontend/src/components/ManageSchema.vue
@@ -89,7 +89,7 @@
 
       <v-card-actions>
         <v-layout align-end justify-end>
-          <v-btn color="primary" text @click="closed">Close</v-btn>
+          <v-btn color="primary" @click="closed">Close</v-btn>
         </v-layout>
       </v-card-actions>
     </v-card>

--- a/frontend/src/components/OrganizationalProfile.vue
+++ b/frontend/src/components/OrganizationalProfile.vue
@@ -72,8 +72,9 @@
                 v-if="
                   !isReadOnly && index === documentData.identifier.length - 1
                 "
-                color="primary"
+                color="secondary"
                 text
+                outlined
                 @click="addIdentifier"
                 >Add</v-btn
               >

--- a/frontend/src/components/OrganizationalProfile.vue
+++ b/frontend/src/components/OrganizationalProfile.vue
@@ -68,15 +68,13 @@
           </v-col>
           <v-col v-if="!isReadOnly" cols="2" class="py-0">
             <v-layout>
-              <v-btn
+              <v-bpa-button
                 v-if="
                   !isReadOnly && index === documentData.identifier.length - 1
                 "
                 color="secondary"
-                text
-                outlined
                 @click="addIdentifier"
-                >Add</v-btn
+                >Add</v-bpa-button
               >
               <v-btn
                 icon
@@ -159,6 +157,7 @@
 
 <script>
 import { profileModel } from "../models/model";
+import VBpaButton from "@/components/BpaButton";
 export default {
   props: {
     isReadOnly: Boolean,
@@ -195,6 +194,6 @@ export default {
       this.intDoc.label = event;
     },
   },
-  components: {},
+  components: {VBpaButton},
 };
 </script>

--- a/frontend/src/components/TrustedIssuers.vue
+++ b/frontend/src/components/TrustedIssuers.vue
@@ -64,8 +64,8 @@
       </v-col>
     </v-row>
     <v-row>
-      <v-btn :disabled="isEdit" color="secondary" text outlined @click="addTrustedIssuer"
-        >Add trusted issuer</v-btn
+      <v-bpa-button :disabled="isEdit" color="secondary" @click="addTrustedIssuer"
+        >Add trusted issuer</v-bpa-button
       >
     </v-row>
   </v-container>
@@ -73,7 +73,9 @@
 
 <script>
 import { EventBus } from "../main";
+import VBpaButton from "@/components/BpaButton";
 export default {
+  components: {VBpaButton},
   props: {
     schema: {
       type: Object,

--- a/frontend/src/components/TrustedIssuers.vue
+++ b/frontend/src/components/TrustedIssuers.vue
@@ -32,7 +32,7 @@
           v-if="!entry.isReadOnly && !entry.isEdit"
           :disabled="isEdit"
           color="primary"
-          text
+          icon
           @click="editTrustedIssuer(index)"
           ><v-icon>$vuetify.icons.pencil</v-icon></v-btn
         >
@@ -41,15 +41,15 @@
           v-if="!entry.isReadOnly && entry.isEdit"
           :loading="isBusy"
           color="primary"
-          text
+          icon
           @click="saveTrustedIssuer(entry)"
           ><v-icon>$vuetify.icons.save</v-icon></v-btn
         >
 
         <v-btn
           v-if="!entry.isReadOnly && entry.isEdit"
-          color="secondary"
-          text
+          color="error"
+          icon
           @click="cancelEditTrustedIssuer(index)"
           ><v-icon>$vuetify.icons.cancel</v-icon></v-btn
         >
@@ -64,7 +64,7 @@
       </v-col>
     </v-row>
     <v-row>
-      <v-btn :disabled="isEdit" color="primary" text @click="addTrustedIssuer"
+      <v-btn :disabled="isEdit" color="secondary" text outlined @click="addTrustedIssuer"
         >Add trusted issuer</v-btn
       >
     </v-row>

--- a/frontend/src/components/taa/TransactionAuthorAgreement.vue
+++ b/frontend/src/components/taa/TransactionAuthorAgreement.vue
@@ -35,9 +35,9 @@
           </v-card-text>
           <v-card-actions>
             <v-spacer></v-spacer>
-            <v-btn :disabled="!valid" color="primary" @click="register">
+            <v-bpa-button :disabled="!valid" color="primary" @click="register">
               Write endpoints to ledger
-            </v-btn>
+            </v-bpa-button>
           </v-card-actions>
         </v-card>
       </v-form>
@@ -47,10 +47,12 @@
 <script>
 import { mapActions, mapGetters } from "vuex";
 import VueMarkdown from "vue-markdown-render";
+import VBpaButton from "@/components/BpaButton";
 
 export default {
   props: {},
   components: {
+    VBpaButton,
     "v-markdown": VueMarkdown,
   },
   data() {

--- a/frontend/src/views/AddPartner.vue
+++ b/frontend/src/views/AddPartner.vue
@@ -62,13 +62,13 @@
       </v-container>
       <v-card-actions>
         <v-layout justify-space-between>
-          <v-btn color="secondary" text outlined to="/app/partners">Cancel</v-btn>
+          <v-bpa-button color="secondary" to="/app/partners">Cancel</v-bpa-button>
 
-          <v-btn v-if="!partnerLoaded" color="primary" @click="lookup()"
-            >Lookup Partner</v-btn
+          <v-bpa-button v-if="!partnerLoaded" color="primary" @click="lookup()"
+            >Lookup Partner</v-bpa-button
           >
-          <v-btn v-else color="primary" @click="addPartner()"
-            >Add Partner</v-btn
+          <v-bpa-button v-else color="primary" @click="addPartner()"
+            >Add Partner</v-bpa-button
           >
         </v-layout>
       </v-card-actions>
@@ -80,9 +80,11 @@
 import Profile from "@/components/Profile";
 import { getPartnerName } from "../utils/partnerUtils";
 import { EventBus } from "../main";
+import VBpaButton from "@/components/BpaButton";
 export default {
   name: "AddPartner",
   components: {
+    VBpaButton,
     Profile,
   },
   created: () => {},

--- a/frontend/src/views/AddPartner.vue
+++ b/frontend/src/views/AddPartner.vue
@@ -62,7 +62,7 @@
       </v-container>
       <v-card-actions>
         <v-layout justify-space-between>
-          <v-btn color="secondary" text to="/app/partners">Cancel</v-btn>
+          <v-btn color="secondary" text outlined to="/app/partners">Cancel</v-btn>
 
           <v-btn v-if="!partnerLoaded" color="primary" @click="lookup()"
             >Lookup Partner</v-btn

--- a/frontend/src/views/AddPartnerbyURL.vue
+++ b/frontend/src/views/AddPartnerbyURL.vue
@@ -14,7 +14,7 @@
       <v-container>
         <v-row v-if="!invitationURL">
           <v-col cols="12">
-              <v-btn color="secondary" text @click="createInvitation()">Generate QR Code</v-btn>
+              <v-bpa-button color="secondary" @click="createInvitation()">Generate QR Code</v-bpa-button>
           </v-col>
         </v-row>
         <v-row v-else>
@@ -30,7 +30,7 @@
       </v-container>
       <v-card-actions>
         <v-layout justify-space-between>
-          <v-btn color="secondary" text outlined to="/app/partners">Return</v-btn>
+          <v-bpa-button color="secondary" to="/app/partners">Return</v-bpa-button>
         </v-layout>
       </v-card-actions>
     </v-card>
@@ -40,10 +40,12 @@
 <script>
 import { EventBus } from "../main";
 import QrcodeVue from 'qrcode.vue'
+import VBpaButton from "@/components/BpaButton";
 export default {
   name: "AddPartnerbyURL",
   created: () => {},
   components: {
+    VBpaButton,
     QrcodeVue,
   },
   data: () => {

--- a/frontend/src/views/AddPartnerbyURL.vue
+++ b/frontend/src/views/AddPartnerbyURL.vue
@@ -2,7 +2,7 @@
  Copyright (c) 2020 - for information on the respective copyright owner
  see the NOTICE file and/or the repository at
  https://github.com/hyperledger-labs/organizational-agent
- 
+
  SPDX-License-Identifier: Apache-2.0
 -->
 <template>
@@ -14,7 +14,7 @@
       <v-container>
         <v-row v-if="!invitationURL">
           <v-col cols="12">
-              <v-btn color="Primary" text @click="createInvitation()">GenerateURL</v-btn>
+              <v-btn color="secondary" text @click="createInvitation()">Generate QR Code</v-btn>
           </v-col>
         </v-row>
         <v-row v-else>
@@ -26,11 +26,11 @@
               <span class="font-weight-light">{{ invitationURL }}</span>
             </div>
           </v-col>
-        </v-row>      
+        </v-row>
       </v-container>
       <v-card-actions>
         <v-layout justify-space-between>
-          <v-btn color="secondary" text to="/app/partners">Return</v-btn>
+          <v-btn color="secondary" text outlined to="/app/partners">Return</v-btn>
         </v-layout>
       </v-card-actions>
     </v-card>
@@ -88,7 +88,7 @@ export default {
             EventBus.$emit("error", e);
           }
         });
-    },    
+    },
   },
 };
 </script>

--- a/frontend/src/views/AddSchema.vue
+++ b/frontend/src/views/AddSchema.vue
@@ -56,14 +56,14 @@
 
       <v-card-actions>
         <v-layout justify-end>
-          <v-btn
+          <v-bpa-button
             :loading="this.isBusyAddSchema"
             :disabled="fieldsEmpty"
             color="primary"
             @click="addSchema"
           >
             Submit
-          </v-btn>
+          </v-bpa-button>
         </v-layout>
       </v-card-actions>
     </v-card>
@@ -73,9 +73,11 @@
 <script>
 import { EventBus } from "../main";
 import TrustedIssuer from "../components/TrustedIssuers.vue";
+import VBpaButton from "@/components/BpaButton";
 export default {
   name: "AddSchema",
   components: {
+    VBpaButton,
     TrustedIssuer,
   },
   created: () => {},

--- a/frontend/src/views/ContactPerson.vue
+++ b/frontend/src/views/ContactPerson.vue
@@ -94,14 +94,14 @@
       ></v-text-field>
       <v-card-actions>
         <v-layout justify-space-between>
-          <v-btn color="secondary" text outlined :to="{ name: 'AddDocument' }">Cancel</v-btn>
-          <v-btn
+          <v-bpa-button color="secondary" :to="{ name: 'AddDocument' }">Cancel</v-bpa-button>
+          <v-bpa-button
             color="primary"
             :to="{
               name: 'AddDocument',
               params: { person: person },
             }"
-            >Save</v-btn
+            >Save</v-bpa-button
           >
         </v-layout>
       </v-card-actions>
@@ -111,8 +111,10 @@
 
 <script>
 import { EventBus } from "../main";
+import VBpaButton from "@/components/BpaButton";
 export default {
   name: "ContactPerson",
+  components: {VBpaButton},
   props: {
     person: {
       type: Object,

--- a/frontend/src/views/ContactPerson.vue
+++ b/frontend/src/views/ContactPerson.vue
@@ -2,7 +2,7 @@
  Copyright (c) 2020 - for information on the respective copyright owner
  see the NOTICE file and/or the repository at
  https://github.com/hyperledger-labs/organizational-agent
- 
+
  SPDX-License-Identifier: Apache-2.0
 -->
 <template>
@@ -94,10 +94,9 @@
       ></v-text-field>
       <v-card-actions>
         <v-layout justify-space-between>
-          <v-btn text :to="{ name: 'AddDocument' }">Cancel</v-btn>
+          <v-btn color="secondary" text outlined :to="{ name: 'AddDocument' }">Cancel</v-btn>
           <v-btn
             color="primary"
-            text
             :to="{
               name: 'AddDocument',
               params: { person: person },

--- a/frontend/src/views/Credential.vue
+++ b/frontend/src/views/Credential.vue
@@ -52,12 +52,12 @@
       </v-card-text>
       <v-card-actions>
         <v-layout align-end justify-end>
-          <v-btn color="secondary" text outlined @click="cancel()">Cancel</v-btn>
-          <v-btn
+          <v-bpa-button color="secondary" @click="cancel()">Cancel</v-bpa-button>
+          <v-bpa-button
             :loading="this.isBusy"
             color="primary"
             @click="saveChanges()"
-            >Save</v-btn
+            >Save</v-bpa-button
           >
         </v-layout>
       </v-card-actions>
@@ -80,6 +80,7 @@
 import { EventBus } from "../main";
 import Cred from "@/components/Credential";
 import { CredentialTypes } from "../constants";
+import VBpaButton from "@/components/BpaButton";
 
 export default {
   name: "Credential",
@@ -205,6 +206,7 @@ export default {
     },
   },
   components: {
+    VBpaButton,
     Cred,
   },
 };

--- a/frontend/src/views/Credential.vue
+++ b/frontend/src/views/Credential.vue
@@ -52,11 +52,10 @@
       </v-card-text>
       <v-card-actions>
         <v-layout align-end justify-end>
-          <v-btn color="secondary" text @click="cancel()">Cancel</v-btn>
+          <v-btn color="secondary" text outlined @click="cancel()">Cancel</v-btn>
           <v-btn
             :loading="this.isBusy"
             color="primary"
-            text
             @click="saveChanges()"
             >Save</v-btn
           >

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -39,13 +39,13 @@
       </p>
       <!-- <p v-bind:style="{ fontSize: `140%` }" class="grey--text text--darken-2 font-weight-medium">Start by adding a public profile that your business partners will see</p> -->
       <br />
-      <v-btn
+      <v-bpa-button
         color="primary"
         :to="{
           name: 'DocumentAdd',
           params: { type: CredentialTypes.PROFILE.type },
         }"
-        >Setup your Profile</v-btn
+        >Setup your Profile</v-bpa-button
       >
     </div>
     <div v-if="!isWelcome && !isLoading">
@@ -101,8 +101,10 @@
 <script>
 import { EventBus } from "../main";
 import { CredentialTypes } from "../constants";
+import VBpaButton from "@/components/BpaButton";
 export default {
   name: "Dashboard",
+  components: {VBpaButton},
   created() {
     EventBus.$emit("title", "Dashboard");
     this.getStatus();

--- a/frontend/src/views/Document.vue
+++ b/frontend/src/views/Document.vue
@@ -100,19 +100,19 @@
 
       <v-card-actions>
         <v-layout align-end justify-end>
-          <v-btn color="secondary" text outlined @click="cancel()">Cancel</v-btn>
-          <v-btn
+          <v-bpa-button color="secondary" @click="cancel()">Cancel</v-bpa-button>
+          <v-bpa-button
             :loading="this.isBusy"
             color="primary"
             @click="saveDocument(false || isProfile(intDoc.type))"
-            >Save</v-btn
+            >Save</v-bpa-button
           >
-          <v-btn
+          <v-bpa-button
             v-show="this.id && !isProfile(intDoc.type)"
             :loading="this.isBusy"
             color="primary"
             @click="saveDocument(true && !isProfile(intDoc.type))"
-            >Save & Close</v-btn
+            >Save & Close</v-bpa-button
           >
         </v-layout>
       </v-card-actions>
@@ -137,6 +137,7 @@ import { EventBus } from "../main";
 import { CredentialTypes } from "../constants";
 import OrganizationalProfile from "@/components/OrganizationalProfile";
 import Credential from "@/components/Credential";
+import VBpaButton from "@/components/BpaButton";
 
 export default {
   name: "Document",
@@ -312,6 +313,7 @@ export default {
     },
   },
   components: {
+    VBpaButton,
     OrganizationalProfile,
     Credential,
   },

--- a/frontend/src/views/Document.vue
+++ b/frontend/src/views/Document.vue
@@ -100,11 +100,10 @@
 
       <v-card-actions>
         <v-layout align-end justify-end>
-          <v-btn color="secondary" text @click="cancel()">Cancel</v-btn>
+          <v-btn color="secondary" text outlined @click="cancel()">Cancel</v-btn>
           <v-btn
             :loading="this.isBusy"
             color="primary"
-            text
             @click="saveDocument(false || isProfile(intDoc.type))"
             >Save</v-btn
           >
@@ -112,7 +111,6 @@
             v-show="this.id && !isProfile(intDoc.type)"
             :loading="this.isBusy"
             color="primary"
-            text
             @click="saveDocument(true && !isProfile(intDoc.type))"
             >Save & Close</v-btn
           >

--- a/frontend/src/views/Partner.vue
+++ b/frontend/src/views/Partner.vue
@@ -24,12 +24,11 @@
           dense
         >
           <template v-slot:append>
-            <v-btn class="pb-1" text @click="isUpdatingName = false"
+            <v-btn class="pb-1" text outlined @click="isUpdatingName = false"
               >Cancel</v-btn
             >
             <v-btn
               class="pb-1"
-              text
               color="primary"
               :loading="isBusy"
               @click="submitNameUpdate()"
@@ -60,12 +59,11 @@
             dense
           >
             <template v-slot:append>
-              <v-btn class="pb-1" text @click="isUpdatingDid = false"
+              <v-btn class="pb-1" text outlined @click="isUpdatingDid = false"
                 >Cancel</v-btn
               >
               <v-btn
                 class="pb-1"
-                text
                 color="primary"
                 :loading="isBusy"
                 @click="submitDidUpdate()"
@@ -118,10 +116,10 @@
               >{{ this.alias }} wants to create a connection with you.</v-row
             >
             <template v-slot:actions>
-              <v-btn text color="seconday" @click="deletePartner">
+              <v-btn text outlined color="secondary" @click="deletePartner">
                 Remove Partner
               </v-btn>
-              <v-btn text color="primary" @click="acceptPartnerRequest">
+              <v-btn color="primary" @click="acceptPartnerRequest">
                 Accept
               </v-btn>
             </template>
@@ -288,11 +286,12 @@
           <v-btn
             color="secondary"
             text
+            outlined
             @click="attentionPartnerStateDialog = false"
             >No</v-btn
           >
 
-          <v-btn color="primary" text @click="proceed">Yes</v-btn>
+          <v-btn color="primary" @click="proceed">Yes</v-btn>
         </v-card-actions>
       </v-card>
     </v-dialog>

--- a/frontend/src/views/Partner.vue
+++ b/frontend/src/views/Partner.vue
@@ -24,15 +24,15 @@
           dense
         >
           <template v-slot:append>
-            <v-btn class="pb-1" text outlined @click="isUpdatingName = false"
-              >Cancel</v-btn
+            <v-bpa-button color="secondary" class="pb-1" @click="isUpdatingName = false"
+              >Cancel</v-bpa-button
             >
-            <v-btn
+            <v-bpa-button
               class="pb-1"
               color="primary"
               :loading="isBusy"
               @click="submitNameUpdate()"
-              >Save</v-btn
+              >Save</v-bpa-button
             >
           </template>
         </v-text-field>
@@ -59,15 +59,15 @@
             dense
           >
             <template v-slot:append>
-              <v-btn class="pb-1" text outlined @click="isUpdatingDid = false"
-                >Cancel</v-btn
+              <v-bpa-button color="secondary" class="pb-1" @click="isUpdatingDid = false"
+                >Cancel</v-bpa-button
               >
-              <v-btn
+              <v-bpa-button
                 class="pb-1"
                 color="primary"
                 :loading="isBusy"
                 @click="submitDidUpdate()"
-                >Save</v-btn
+                >Save</v-bpa-button
               >
             </template>
           </v-text-field>
@@ -76,7 +76,7 @@
           </v-btn>
           <v-tooltip top>
             <template v-slot:activator="{ on, attrs }">
-              <v-btn
+              <v-bpa-button
                 color="primary"
                 v-bind="attrs"
                 v-on="on"
@@ -84,7 +84,7 @@
                 @click="refreshPartner()"
               >
                 <v-icon dark>$vuetify.icons.refresh</v-icon>
-              </v-btn>
+              </v-bpa-button>
             </template>
             <span>Refresh profile from source</span>
           </v-tooltip>
@@ -116,12 +116,12 @@
               >{{ this.alias }} wants to create a connection with you.</v-row
             >
             <template v-slot:actions>
-              <v-btn text outlined color="secondary" @click="deletePartner">
+              <v-bpa-button color="secondary" @click="deletePartner">
                 Remove Partner
-              </v-btn>
-              <v-btn color="primary" @click="acceptPartnerRequest">
+              </v-bpa-button>
+              <v-bpa-button color="primary" @click="acceptPartnerRequest">
                 Accept
-              </v-btn>
+              </v-bpa-button>
             </template>
           </v-banner>
         </template>
@@ -283,15 +283,13 @@
         <v-card-actions>
           <v-spacer></v-spacer>
 
-          <v-btn
+          <v-bpa-button
             color="secondary"
-            text
-            outlined
             @click="attentionPartnerStateDialog = false"
-            >No</v-btn
+            >No</v-bpa-button
           >
 
-          <v-btn color="primary" @click="proceed">Yes</v-btn>
+          <v-bpa-button color="primary" @click="proceed">Yes</v-bpa-button>
         </v-card-actions>
       </v-card>
     </v-dialog>
@@ -317,11 +315,13 @@ import { issuerService } from "@/services";
 import CredExList from "@/components/CredExList";
 import IssueCredential from "@/components/IssueCredential";
 import PresentationRequestList from "@/components/PresentationRequestList";
+import VBpaButton from "@/components/BpaButton";
 
 export default {
   name: "Partner",
   props: ["id"],
   components: {
+    VBpaButton,
     Profile,
     PresentationList,
     PartnerStateIndicator,

--- a/frontend/src/views/Presentation.vue
+++ b/frontend/src/views/Presentation.vue
@@ -44,8 +44,8 @@
 
       <!-- <v-card-actions>
       <v-layout align-end justify-end>
-        <v-btn color="secondary" text @click="cancel()">Cancel</v-btn>
-        <v-btn :loading="this.isBusy" color="primary" text @click="saveChanges()">Save</v-btn>
+        <v-btn color="secondary" text outlined @click="cancel()">Cancel</v-btn>
+        <v-btn :loading="this.isBusy" color="primary" @click="saveChanges()">Save</v-btn>
       </v-layout>
     </v-card-actions> -->
     </v-card>

--- a/frontend/src/views/PublicProfile.vue
+++ b/frontend/src/views/PublicProfile.vue
@@ -2,7 +2,7 @@
  Copyright (c) 2020 - for information on the respective copyright owner
  see the NOTICE file and/or the repository at
  https://github.com/hyperledger-labs/organizational-agent
- 
+
  SPDX-License-Identifier: Apache-2.0
 -->
 <template>

--- a/frontend/src/views/RequestPresentation.vue
+++ b/frontend/src/views/RequestPresentation.vue
@@ -43,7 +43,7 @@
 
                 <v-card-actions>
                   <v-layout align-end justify-end>
-                    <v-btn color="secondary" text @click="cancel()"
+                    <v-btn color="secondary" text outlined @click="cancel()"
                       >Cancel</v-btn
                     >
                     <v-btn
@@ -74,7 +74,7 @@
 
                 <v-card-actions>
                   <v-layout align-end justify-end>
-                    <v-btn color="secondary" text @click="step = 1">Back</v-btn>
+                    <v-btn color="secondary" text outlined @click="step = 1">Back</v-btn>
 
                     <v-btn
                       :loading="this.isBusy"

--- a/frontend/src/views/RequestPresentation.vue
+++ b/frontend/src/views/RequestPresentation.vue
@@ -43,14 +43,14 @@
 
                 <v-card-actions>
                   <v-layout align-end justify-end>
-                    <v-btn color="secondary" text outlined @click="cancel()"
-                      >Cancel</v-btn
+                    <v-bpa-button color="secondary" @click="cancel()"
+                      >Cancel</v-bpa-button
                     >
-                    <v-btn
+                    <v-bpa-button
                       :disabled="selectedSchema.length === 0"
                       color="primary"
                       @click="step = 2"
-                      >Continue</v-btn
+                      >Continue</v-bpa-button
                     >
                   </v-layout>
                 </v-card-actions>
@@ -74,13 +74,13 @@
 
                 <v-card-actions>
                   <v-layout align-end justify-end>
-                    <v-btn color="secondary" text outlined @click="step = 1">Back</v-btn>
+                    <v-bpa-button color="secondary" @click="step = 1">Back</v-bpa-button>
 
-                    <v-btn
+                    <v-bpa-button
                       :loading="this.isBusy"
                       color="primary"
                       @click="submitRequest()"
-                      >Send Request</v-btn
+                      >Send Request</v-bpa-button
                     >
                   </v-layout>
                 </v-card-actions>
@@ -95,10 +95,11 @@
 
 <script>
 import { EventBus } from "../main";
+import VBpaButton from "@/components/BpaButton";
 
 export default {
   name: "RequestPresentation",
-  components: {},
+  components: {VBpaButton},
   props: {
     id: String, //partner ID
   },

--- a/frontend/src/views/RequestVerification.vue
+++ b/frontend/src/views/RequestVerification.vue
@@ -28,12 +28,12 @@
 
       <v-card-actions>
         <v-layout align-end justify-end>
-          <v-btn color="secondary" text outlined @click="cancel()">Cancel</v-btn>
-          <v-btn
+          <v-bpa-button color="secondary" @click="cancel()">Cancel</v-bpa-button>
+          <v-bpa-button
             :loading="this.isBusy"
             color="primary"
             @click="checkRequest"
-            >Submit</v-btn
+            >Submit</v-bpa-button
           >
         </v-layout>
       </v-card-actions>
@@ -53,15 +53,13 @@
         <v-card-actions>
           <v-spacer></v-spacer>
 
-          <v-btn
+          <v-bpa-button
             color="secondary"
-            text
-            outlined
             @click="attentionPartnerStateDialog = false"
-            >No</v-btn
+            >No</v-bpa-button
           >
 
-          <v-btn color="primary" @click="submitRequest">Yes</v-btn>
+          <v-bpa-button color="primary" @click="submitRequest">Yes</v-bpa-button>
         </v-card-actions>
       </v-card>
     </v-dialog>
@@ -71,11 +69,13 @@
 <script>
 import { EventBus } from "../main";
 import PartnerList from "@/components/PartnerList";
+import VBpaButton from "@/components/BpaButton";
 // import { CredentialTypes } from "../constants";
 
 export default {
   name: "RequestVerification",
   components: {
+    VBpaButton,
     PartnerList,
   },
   props: {

--- a/frontend/src/views/RequestVerification.vue
+++ b/frontend/src/views/RequestVerification.vue
@@ -28,11 +28,10 @@
 
       <v-card-actions>
         <v-layout align-end justify-end>
-          <v-btn color="secondary" text @click="cancel()">Cancel</v-btn>
+          <v-btn color="secondary" text outlined @click="cancel()">Cancel</v-btn>
           <v-btn
             :loading="this.isBusy"
             color="primary"
-            text
             @click="checkRequest"
             >Submit</v-btn
           >
@@ -57,11 +56,12 @@
           <v-btn
             color="secondary"
             text
+            outlined
             @click="attentionPartnerStateDialog = false"
             >No</v-btn
           >
 
-          <v-btn color="primary" text @click="submitRequest">Yes</v-btn>
+          <v-btn color="primary" @click="submitRequest">Yes</v-btn>
         </v-card-actions>
       </v-card>
     </v-dialog>

--- a/frontend/src/views/Schema.vue
+++ b/frontend/src/views/Schema.vue
@@ -55,8 +55,8 @@
       </v-container>
       <v-card-actions>
         <v-layout align-end justify-end>
-          <v-btn color="primary" text :to="{ name: 'SchemaSettings' }"
-            >Close</v-btn
+          <v-bpa-button color="primary" :to="{ name: 'SchemaSettings' }"
+            >Close</v-bpa-button
           >
         </v-layout>
       </v-card-actions>
@@ -67,6 +67,7 @@
 <script>
 import { EventBus } from "../main";
 import TrustedIssuers from "../components/TrustedIssuers";
+import VBpaButton from "@/components/BpaButton";
 export default {
   name: "Schema",
   props: {
@@ -74,6 +75,7 @@ export default {
     schema: Object,
   },
   components: {
+    VBpaButton,
     TrustedIssuers,
   },
   mounted() {

--- a/frontend/src/views/SchemaSettings.vue
+++ b/frontend/src/views/SchemaSettings.vue
@@ -24,8 +24,8 @@
         <v-layout align-end justify-end>
           <v-dialog v-model="createSchemaDialog" persistent max-width="600px">
             <template v-slot:activator="{ on, attrs }">
-              <v-btn v-bind="attrs" v-on="on" color="secondary" text outlined
-              >Create Schema</v-btn
+              <v-bpa-button v-bind="attrs" v-on="on" color="secondary"
+              >Create Schema</v-bpa-button
               >
             </template>
             <CreateSchema
@@ -35,8 +35,8 @@
           </v-dialog>
           <v-dialog v-model="addSchemaDialog" persistent max-width="600px">
             <template v-slot:activator="{ on, attrs }">
-              <v-btn v-bind="attrs" v-on="on" color="primary"
-                >Import Schema</v-btn
+              <v-bpa-button v-bind="attrs" v-on="on" color="primary"
+                >Import Schema</v-bpa-button
               >
             </template>
             <AddSchema
@@ -57,10 +57,12 @@ import AddSchema from "@/components/AddSchema";
 import CreateSchema from "@/components/CreateSchema";
 
 import store from "@/store";
+import VBpaButton from "@/components/BpaButton";
 
 export default {
   name: "SchemaSettings",
   components: {
+    VBpaButton,
     AddSchema,
     CreateSchema,
     SchemaList,

--- a/frontend/src/views/SchemaSettings.vue
+++ b/frontend/src/views/SchemaSettings.vue
@@ -22,6 +22,17 @@
       </v-card-text>
       <v-card-actions>
         <v-layout align-end justify-end>
+          <v-dialog v-model="createSchemaDialog" persistent max-width="600px">
+            <template v-slot:activator="{ on, attrs }">
+              <v-btn v-bind="attrs" v-on="on" color="secondary" text outlined
+              >Create Schema</v-btn
+              >
+            </template>
+            <CreateSchema
+                @success="onSchemaCreated"
+                @cancelled="createSchemaDialog = false"
+            />
+          </v-dialog>
           <v-dialog v-model="addSchemaDialog" persistent max-width="600px">
             <template v-slot:activator="{ on, attrs }">
               <v-btn v-bind="attrs" v-on="on" color="primary"
@@ -31,17 +42,6 @@
             <AddSchema
               @success="onSchemaAdded"
               @cancelled="addSchemaDialog = false"
-            />
-          </v-dialog>
-          <v-dialog v-model="createSchemaDialog" persistent max-width="600px">
-            <template v-slot:activator="{ on, attrs }">
-              <v-btn v-bind="attrs" v-on="on" color="primary"
-                >Create Schema</v-btn
-              >
-            </template>
-            <CreateSchema
-              @success="onSchemaCreated"
-              @cancelled="createSchemaDialog = false"
             />
           </v-dialog>
         </v-layout>

--- a/frontend/src/views/SendPresentation.vue
+++ b/frontend/src/views/SendPresentation.vue
@@ -27,11 +27,10 @@
 
       <v-card-actions>
         <v-layout align-end justify-end>
-          <v-btn color="secondary" text @click="cancel()">Cancel</v-btn>
+          <v-btn color="secondary" text outlined @click="cancel()">Cancel</v-btn>
           <v-btn
             :loading="this.isBusy"
             color="primary"
-            text
             @click="sendPresentation()"
             >Submit</v-btn
           >

--- a/frontend/src/views/SendPresentation.vue
+++ b/frontend/src/views/SendPresentation.vue
@@ -27,12 +27,12 @@
 
       <v-card-actions>
         <v-layout align-end justify-end>
-          <v-btn color="secondary" text outlined @click="cancel()">Cancel</v-btn>
-          <v-btn
+          <v-bpa-button color="secondary" @click="cancel()">Cancel</v-bpa-button>
+          <v-bpa-button
             :loading="this.isBusy"
             color="primary"
             @click="sendPresentation()"
-            >Submit</v-btn
+            >Submit</v-bpa-button
           >
         </v-layout>
       </v-card-actions>
@@ -45,10 +45,12 @@ import { EventBus } from "../main";
 
 // import { CredentialTypes } from "../constants";
 import MyCredentialList from "@/components/MyCredentialList";
+import VBpaButton from "@/components/BpaButton";
 
 export default {
   name: "SendPresentation",
   components: {
+    VBpaButton,
     MyCredentialList,
   },
   props: {

--- a/frontend/src/views/issuer/CredentialManagement.vue
+++ b/frontend/src/views/issuer/CredentialManagement.vue
@@ -20,6 +20,17 @@
       </v-card-text>
       <v-card-actions>
         <v-layout align-end justify-end>
+          <v-dialog v-model="createSchemaDialog" persistent max-width="600px">
+            <template v-slot:activator="{ on, attrs }">
+              <v-btn v-bind="attrs" v-on="on" color="secondary" text outlined
+              >Create Schema</v-btn
+              >
+            </template>
+            <CreateSchema
+                @success="onSchemaCreated"
+                @cancelled="createSchemaDialog = false"
+            />
+          </v-dialog>
           <v-dialog v-model="addSchemaDialog" persistent max-width="600px">
             <template v-slot:activator="{ on, attrs }">
               <v-btn v-bind="attrs" v-on="on" color="primary"
@@ -29,17 +40,6 @@
             <AddSchema
               @success="onSchemaAdded"
               @cancelled="addSchemaDialog = false"
-            />
-          </v-dialog>
-          <v-dialog v-model="createSchemaDialog" persistent max-width="600px">
-            <template v-slot:activator="{ on, attrs }">
-              <v-btn v-bind="attrs" v-on="on" color="primary"
-                >Create Schema</v-btn
-              >
-            </template>
-            <CreateSchema
-              @success="onSchemaCreated"
-              @cancelled="createSchemaDialog = false"
             />
           </v-dialog>
         </v-layout>

--- a/frontend/src/views/issuer/CredentialManagement.vue
+++ b/frontend/src/views/issuer/CredentialManagement.vue
@@ -22,8 +22,8 @@
         <v-layout align-end justify-end>
           <v-dialog v-model="createSchemaDialog" persistent max-width="600px">
             <template v-slot:activator="{ on, attrs }">
-              <v-btn v-bind="attrs" v-on="on" color="secondary" text outlined
-              >Create Schema</v-btn
+              <v-bpa-button v-bind="attrs" v-on="on" color="secondary"
+              >Create Schema</v-bpa-button
               >
             </template>
             <CreateSchema
@@ -33,8 +33,8 @@
           </v-dialog>
           <v-dialog v-model="addSchemaDialog" persistent max-width="600px">
             <template v-slot:activator="{ on, attrs }">
-              <v-btn v-bind="attrs" v-on="on" color="primary"
-                >Import Schema</v-btn
+              <v-bpa-button v-bind="attrs" v-on="on" color="primary"
+                >Import Schema</v-bpa-button
               >
             </template>
             <AddSchema
@@ -110,12 +110,12 @@
             max-width="600px"
           >
             <template v-slot:activator="{ on, attrs }">
-              <v-btn
+              <v-bpa-button
                 v-bind="attrs"
                 v-on="on"
                 color="primary"
                 :disabled="issueCredentialDisabled"
-                >Issue Credential</v-btn
+                >Issue Credential</v-bpa-button
               >
             </template>
             <IssueCredential
@@ -145,10 +145,12 @@ import SchemaList from "@/components/SchemaList";
 import * as textUtils from "@/utils/textUtils";
 import * as partnerUtils from "@/utils/partnerUtils";
 import store from "@/store";
+import VBpaButton from "@/components/BpaButton";
 
 export default {
   name: "CredentialManagement",
   components: {
+    VBpaButton,
     SchemaList,
     AddSchema,
     CreateSchema,


### PR DESCRIPTION
Try for only one Primary per section/form.

For BC Gov our [secondary buttons](https://developer.gov.bc.ca/Design-System/Secondary-Button) are supposed to be outlined and text. So if there are no objections, I'd like to put this in place. It is much easier to set on the VUE components themselves than to attempt via SASS overrides or CSS.

We may want to set a specific secondary color for our default theme. The default color is `#424242` which may be too dark?
For our BC theme, we are setting secondary = primary. This shouldn't be a problem until we use secondary for another purpose.

Signed-off-by: Jason Sherman <jsherman@parcsystems.ca>

### Default Look and Feel
![Screen Shot 2021-06-16 at 4 53 08 PM](https://user-images.githubusercontent.com/39388115/122310354-056f6e00-cec5-11eb-8ebc-9fe879e00bf6.png)


### BC Gov Look and Feel
![Screen Shot 2021-06-16 at 4 52 00 PM](https://user-images.githubusercontent.com/39388115/122310118-7a8e7380-cec4-11eb-8114-aa5cbe8b582b.png)


