### PR TITLE
Webhook Security

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -44,8 +44,8 @@ Depending on the docker version the .env file either needs to reside in the root
 
 3. Start dependent services
 ```s
-# e.g. run from the root directory
-docker-compose -f scripts/docker-compose.yml up bpa-agent1 bpa-wallet-db1
+# e.g. run from the scripts directory
+docker-compose up bpa-agent1 bpa-wallet-db1
 ```
 
 4. Set VM Options
@@ -74,12 +74,3 @@ If you want to run in web only mode you also have to set:
 
 Swagger UI: http://localhost:8080/swagger-ui   
 Frontend: http://localhost:8080
-
-# Websocket Events
-
-see: WebSocketMessageBody.java
-
-1. Connection Request (no auto flags)
-2. Partner Received (with auto flags)
-3. Credential Received
-4. Proof Received

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/config/acapy/AcaPyAuthFetcher.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/config/acapy/AcaPyAuthFetcher.java
@@ -43,7 +43,7 @@ import java.util.Map;
  * custom {@link AuthenticationFetcher} needs to be provided.
  *
  * The AuthFetcher becomes active if either the environment variable BPA_WEBHOOK_KEY
- * or the system property bpy.webhook.key is set.
+ * or the system property bpa.webhook.key is set.
  */
 @Slf4j
 @Singleton
@@ -64,12 +64,13 @@ public class AcaPyAuthFetcher implements AuthenticationFetcher {
                     && request.getPath().startsWith(AriesWebhookController.WEBHOOK_CONTROLLER_PATH)) {
                 String apiKeyHeader = request.getHeaders().get(X_API_KEY);
                 log.trace("Handling aca-py webhook authentication");
-                if (StringUtils.isNotBlank(apiKeyHeader) && apiKey.equals(apiKeyHeader)) {
+                if (StringUtils.isNotBlank(apiKeyHeader) && apiKeyHeader.equals(apiKey)) {
                     emitter.onSuccess(new AcaPyAuthentication());
                     log.trace("aca-py webhook authentication success");
                     return;
                 }
-                log.error("aca-py webhook authentication failed: {}", apiKeyHeader);
+                log.error("aca-py webhook authentication failed. " +
+                        "Configured bpa.webhook.key: {}, received x-api-key header: {}", apiKey, apiKeyHeader);
             }
             emitter.onComplete();
         }).toFlowable();

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/config/acapy/AcaPyAuthFetcher.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/config/acapy/AcaPyAuthFetcher.java
@@ -76,6 +76,8 @@ public class AcaPyAuthFetcher implements AuthenticationFetcher {
     @NoArgsConstructor
     public static final class AcaPyAuthentication implements Authentication {
 
+        private static final long serialVersionUID = -2423706290718045174L;
+
         @NotNull
         @Override
         public Map<String, Object> getAttributes() {

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/config/acapy/AcaPyAuthFetcher.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/config/acapy/AcaPyAuthFetcher.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2020-2021 - for information on the respective copyright owner
+ * see the NOTICE file and/or the repository at
+ * https://github.com/hyperledger-labs/business-partner-agent
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hyperledger.bpa.config.acapy;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.annotation.Value;
+import io.micronaut.http.HttpMethod;
+import io.micronaut.security.authentication.Authentication;
+import io.micronaut.security.filters.AuthenticationFetcher;
+import io.reactivex.Maybe;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.hyperledger.bpa.controller.AriesWebhookController;
+import org.jetbrains.annotations.NotNull;
+import org.reactivestreams.Publisher;
+
+import javax.inject.Singleton;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Handles aca-py webhook authentication. If the flag --webhook-url is set
+ * aca-py allows setting an api key after an # tag. e.g. --webhook-url
+ * http://localhost/hook/topic#123 The api key is then sent via the x-api-key
+ * HTTP header. As this is not something micronaut handles out of the box, a
+ * custom {@link AuthenticationFetcher} needs to be provided.
+ */
+@Slf4j
+@Singleton
+@Requires(property = "bpa.webhook.apiKey")
+public class AcaPyAuthFetcher implements AuthenticationFetcher {
+
+    private static final String X_API_KEY = "x-api-key";
+
+    public static final String ROLE_ACA_PY = "ROLE_ACA_PY";
+
+    @Value("${bpa.webhook.apiKey}")
+    String apiKey;
+
+    @Override
+    public Publisher<Authentication> fetchAuthentication(io.micronaut.http.HttpRequest<?> request) {
+        return Maybe.<Authentication>create(emitter -> {
+            if (HttpMethod.POST.equals(request.getMethod())
+                    && request.getPath().startsWith(AriesWebhookController.WEBHOOK_CONTROLLER_PATH)) {
+                String apiKeyHeader = request.getHeaders().get(X_API_KEY);
+                log.debug("Handling aca-py webhook authentication");
+                if (StringUtils.isNotBlank(apiKeyHeader) && apiKey.equals(apiKeyHeader)) {
+                    emitter.onSuccess(new AcaPyAuthentication());
+                    log.debug("aca-py webhook authentication success");
+                    return;
+                }
+                log.warn("aca-py webhook authentication failed: {}", apiKeyHeader);
+            }
+            emitter.onComplete();
+        }).toFlowable();
+    }
+
+    @Data
+    @NoArgsConstructor
+    public static final class AcaPyAuthentication implements Authentication {
+
+        @NotNull
+        @Override
+        public Map<String, Object> getAttributes() {
+            return Map.of("roles", List.of(ROLE_ACA_PY));
+        }
+
+        @Override
+        public String getName() {
+            return "aca-py";
+        }
+    }
+}

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/config/acapy/AcaPyAuthFetcherAllowAll.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/config/acapy/AcaPyAuthFetcherAllowAll.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2020-2021 - for information on the respective copyright owner
+ * see the NOTICE file and/or the repository at
+ * https://github.com/hyperledger-labs/business-partner-agent
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hyperledger.bpa.config.acapy;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.HttpMethod;
+import io.micronaut.security.authentication.Authentication;
+import io.micronaut.security.filters.AuthenticationFetcher;
+import io.reactivex.Maybe;
+import lombok.extern.slf4j.Slf4j;
+import org.hyperledger.bpa.controller.AriesWebhookController;
+import org.reactivestreams.Publisher;
+
+import javax.inject.Singleton;
+
+@Slf4j
+@Singleton
+@Requires(missingProperty = "bpa.webhook.apiKey")
+public class AcaPyAuthFetcherAllowAll implements AuthenticationFetcher {
+
+    @Override
+    public Publisher<Authentication> fetchAuthentication(io.micronaut.http.HttpRequest<?> request) {
+        return Maybe.<Authentication>create(emitter -> {
+            if (HttpMethod.POST.equals(request.getMethod())
+                    && request.getPath().startsWith(AriesWebhookController.WEBHOOK_CONTROLLER_PATH)) {
+                log.debug("Handling aca-py webhook authentication");
+                emitter.onSuccess(new AcaPyAuthFetcher.AcaPyAuthentication());
+            }
+            emitter.onComplete();
+        }).toFlowable();
+    }
+}

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/config/acapy/AcaPyAuthFetcherAllowAll.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/config/acapy/AcaPyAuthFetcherAllowAll.java
@@ -28,9 +28,12 @@ import org.reactivestreams.Publisher;
 
 import javax.inject.Singleton;
 
+/**
+ * Backwards compatible AuthFetcher if security is set to true, but no properties are set.
+ */
 @Slf4j
 @Singleton
-@Requires(missingProperty = "bpa.webhook.apiKey")
+@Requires(missingProperty = "bpa.webhook.key")
 public class AcaPyAuthFetcherAllowAll implements AuthenticationFetcher {
 
     @Override
@@ -38,8 +41,9 @@ public class AcaPyAuthFetcherAllowAll implements AuthenticationFetcher {
         return Maybe.<Authentication>create(emitter -> {
             if (HttpMethod.POST.equals(request.getMethod())
                     && request.getPath().startsWith(AriesWebhookController.WEBHOOK_CONTROLLER_PATH)) {
-                log.debug("Handling aca-py webhook authentication");
+                log.trace("Handling aca-py webhook authentication");
                 emitter.onSuccess(new AcaPyAuthFetcher.AcaPyAuthentication());
+                return;
             }
             emitter.onComplete();
         }).toFlowable();

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/controller/AriesWebhookController.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/controller/AriesWebhookController.java
@@ -29,6 +29,7 @@ import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 import org.hyperledger.aries.webhook.EventHandler;
+import org.hyperledger.bpa.config.acapy.AcaPyAuthFetcher;
 
 import javax.inject.Inject;
 import java.util.List;
@@ -40,7 +41,7 @@ import java.util.List;
 @Hidden
 @Tag(name = "Aries Webhook")
 @Controller
-@Secured(SecurityRule.IS_ANONYMOUS)
+@Secured(SecurityRule.IS_AUTHENTICATED)
 @ExecuteOn(TaskExecutors.IO)
 public class AriesWebhookController {
 
@@ -49,6 +50,7 @@ public class AriesWebhookController {
     @Inject
     List<EventHandler> handlers;
 
+    @Secured({ AcaPyAuthFetcher.ROLE_ACA_PY })
     @Post(WEBHOOK_CONTROLLER_PATH + "/{eventType}")
     public void logEvent(
             @PathVariable String eventType,

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/controller/api/partner/PartnerCredentialType.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/controller/api/partner/PartnerCredentialType.java
@@ -38,6 +38,6 @@ public class PartnerCredentialType {
         return new PartnerCredentialType(
                 credDefId,
                 AriesStringUtil.getLastSegment(credDefId),
-                AriesStringUtil.credDefIdGetSquenceNo(credDefId));
+                AriesStringUtil.credDefIdGetSequenceNo(credDefId));
     }
 }

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/aries/config/SchemaService.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/aries/config/SchemaService.java
@@ -129,7 +129,7 @@ public class SchemaService {
             if (ariesSchema.isPresent()) {
                 BPASchema dbS = BPASchema.builder()
                         .label(label)
-                        .schemaId(sId)
+                        .schemaId(ariesSchema.get().getId())
                         .schemaAttributeNames(new LinkedHashSet<>(ariesSchema.get().getAttrNames()))
                         .defaultAttributeName(defaultAttributeName)
                         .seqNo(ariesSchema.get().getSeqNo())

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/util/AriesStringUtil.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/util/AriesStringUtil.java
@@ -37,33 +37,27 @@ public class AriesStringUtil {
     }
 
     public static String schemaGetName(@NonNull String schemaId) {
-        String sId = StringUtils.strip(schemaId);
-        final String[] parts = sId.split(":");
-        if (parts.length != 4) {
-            throw new IllegalArgumentException("Not a valid schema id");
-        }
-        return parts[2];
+        return splitSchemaId(schemaId)[2];
     }
 
     public static String schemaGetCreator(@NonNull String schemaId) {
-        String sId = StringUtils.strip(schemaId);
-        final String[] parts = sId.split(":");
-        if (parts.length != 4) {
-            throw new IllegalArgumentException("Not a valid schema id");
-        }
-        return parts[0];
+        return splitSchemaId(schemaId)[0];
     }
 
     public static String schemaGetVersion(@NonNull String schemaId) {
+        return splitSchemaId(schemaId)[3];
+    }
+
+    private static String[] splitSchemaId(@NonNull String schemaId) {
         String sId = StringUtils.strip(schemaId);
         final String[] parts = sId.split(":");
         if (parts.length != 4) {
-            throw new IllegalArgumentException("Not a valid schema id");
+            throw new IllegalArgumentException(schemaId + " is not a valid schema id");
         }
-        return parts[3];
+        return parts;
     }
 
-    public static String credDefIdGetSquenceNo(@NonNull String credDefId) {
+    public static String credDefIdGetSequenceNo(@NonNull String credDefId) {
         final String[] parts = credDefIdSplit(credDefId);
         return parts[3];
     }

--- a/backend/business-partner-agent/src/test/java/org/hyperledger/bpa/controller/AdminControllerTest.java
+++ b/backend/business-partner-agent/src/test/java/org/hyperledger/bpa/controller/AdminControllerTest.java
@@ -53,6 +53,8 @@ import java.util.UUID;
 @MicronautTest
 public class AdminControllerTest {
 
+    private final String schemaId = "NZhb9EqpN9a6gkHge9fTmv:2:a-schema-name:0.0.1";
+
     @Value("${bpa.did.prefix}")
     String didPrefix;
 
@@ -69,10 +71,9 @@ public class AdminControllerTest {
     @Test
     void testAddSchemaWithRestriction() throws Exception {
         mockGetSchemaAndVerkey();
-        String schemaId = "NZhb9EqpN9a6gkHge9fTmv:2:a-schema-name:0.0.1";
 
         // add schema
-        HttpResponse<SchemaAPI> addedSchema = addSchemaWithRestriction(schemaId);
+        HttpResponse<SchemaAPI> addedSchema = addSchemaWithRestriction();
         Assertions.assertEquals(HttpStatus.OK, addedSchema.getStatus());
         Assertions.assertTrue(addedSchema.getBody().isPresent());
 
@@ -151,7 +152,7 @@ public class AdminControllerTest {
                 .retrieve(HttpRequest.GET("/" + id), SchemaAPI.class);
     }
 
-    private HttpResponse<SchemaAPI> addSchemaWithRestriction(@NonNull String schemaId) {
+    private HttpResponse<SchemaAPI> addSchemaWithRestriction() {
         return client.toBlocking()
                 .exchange(HttpRequest.POST("",
                         AddSchemaRequest.builder()
@@ -180,7 +181,7 @@ public class AdminControllerTest {
     private void mockGetSchemaAndVerkey() throws IOException {
         Mockito.when(ac.schemasGetById(Mockito.anyString())).thenReturn(Optional.of(SchemaSendResponse.Schema
                 .builder()
-                .id("schema1")
+                .id(schemaId)
                 .seqNo(1)
                 .attrNames(List.of("name"))
                 .name("dummy")

--- a/backend/business-partner-agent/src/test/java/org/hyperledger/bpa/impl/util/AriesStringUtilTest.java
+++ b/backend/business-partner-agent/src/test/java/org/hyperledger/bpa/impl/util/AriesStringUtilTest.java
@@ -27,7 +27,7 @@ class AriesStringUtilTest {
 
     @Test
     void testGetSeqNo() {
-        assertEquals("571", AriesStringUtil.credDefIdGetSquenceNo("M6Mbe3qx7vB4wpZF4sBRjt:3:CL:571:bank_account"));
+        assertEquals("571", AriesStringUtil.credDefIdGetSequenceNo("M6Mbe3qx7vB4wpZF4sBRjt:3:CL:571:bank_account"));
     }
 
     @Test

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -54,7 +54,7 @@
         <!-- Dependency Versions -->
         <log4j2.version>2.14.1</log4j2.version>
         <lombok.version>1.18.20</lombok.version>
-        <micronaut.version>2.5.9</micronaut.version>
+        <micronaut.version>2.5.11</micronaut.version>
         <micronaut.data.version>2.4.7</micronaut.data.version>
         <micronaut.openapi.version>2.6.0</micronaut.openapi.version>
         <micronaut.security.version>2.5.0</micronaut.security.version>

--- a/scripts/.env-example
+++ b/scripts/.env-example
@@ -28,6 +28,7 @@ BPA_SECURITY_ENABLED=true
 # Default username and password, set if running in production like environments
 BPA_BOOTSTRAP_UN=admin
 BPA_BOOTSTRAP_PW=changeme
+BPA_WEBHOOK_KEY=changeme
 
 # Run in did:web mode with read only ledger. If set to true ACAPY_READ_ONLY_MODE has to be set as well.
 # Once the mode is set you can not change it again without removing the postgres volume

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       BPA_IMPRINT_URL: ${BPA_IMPRINT_URL}
       BPA_PRIVACY_POLICY_URL: ${BPA_PRIVACY_POLICY_URL}
       BPA_CREDDEF_REVOCATION_REGISTRY_SIZE: ${BPA_CREDDEF_REVOCATION_REGISTRY_SIZE}
+      BPA_WEBHOOK_KEY: ${BPA_WEBHOOK_KEY}
     ports:
       - ${BPA_PORT}:${BPA_PORT}
     restart: always
@@ -46,7 +47,7 @@ services:
         --auto-provision
         --arg-file acapy-static-args.yml \
         --inbound-transport http '0.0.0.0' ${ACAPY_HTTP_PORT} \
-        --webhook-url '${BPA_WEBHOOK_URL}' \
+        --webhook-url '${BPA_WEBHOOK_URL}#${BPA_WEBHOOK_KEY}' \
         --genesis-url '${ACAPY_GENESIS_URL}' \
         --endpoint ${ACAPY_ENDPOINT} \
         --wallet-name '${ACAPY_WALLET_DATABASE}' \
@@ -105,6 +106,7 @@ services:
       BPA_IMPRINT_URL: ${BPA_IMPRINT_URL}
       BPA_PRIVACY_POLICY_URL: ${BPA_PRIVACY_POLICY_URL}
       BPA_CREDDEF_REVOCATION_REGISTRY_SIZE: ${BPA_CREDDEF_REVOCATION_REGISTRY_SIZE}
+      BPA_WEBHOOK_KEY: ${BPA_WEBHOOK_KEY}
     ports:
       - "${BPA2_PORT}:${BPA2_PORT}"
     restart: always
@@ -125,7 +127,7 @@ services:
         --auto-provision
         --arg-file acapy-static-args.yml \
         --inbound-transport http '0.0.0.0' ${ACAPY2_HTTP_PORT} \
-        --webhook-url '${BPA2_WEBHOOK_URL}' \
+        --webhook-url '${BPA2_WEBHOOK_URL}#${BPA_WEBHOOK_KEY}' \
         --genesis-url '${ACAPY_GENESIS_URL}' \
         --endpoint ${ACAPY2_ENDPOINT} \
         --wallet-name '${ACAPY_WALLET_DATABASE}' \


### PR DESCRIPTION
With version 0.5.6 or 0.6 added the possibility to add a secret to the webhook flag. With this feature it is possible to also enable security on the webhook endpoint in the backend.  

Signed-off-by: Philipp Etschel <philipp.etschel@ch.bosch.com>

<a href="https://gitpod.io/#https://github.com/hyperledger-labs/business-partner-agent/pull/560"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

