### PR TITLE
Virtual Partner Name/Alias

### DIFF
--- a/frontend/src/views/AddPartner.vue
+++ b/frontend/src/views/AddPartner.vue
@@ -54,7 +54,7 @@
               label="Name"
               persistent-placeholder
               :placeholder=aliasPlaceholder
-              v-model="alias"
+              v-model.trim="alias"
               outlined
               dense
             >

--- a/frontend/src/views/AddPartner.vue
+++ b/frontend/src/views/AddPartner.vue
@@ -52,7 +52,8 @@
           <v-col cols="8">
             <v-text-field
               label="Name"
-              placeholder=""
+              persistent-placeholder
+              :placeholder=aliasPlaceholder
               v-model="alias"
               outlined
               dense
@@ -88,20 +89,23 @@
           </v-list-item>
         </v-row>
 
-        <Profile v-if="partnerLoaded" v-bind:partner="partner" />
+      <Profile v-if="partnerLoaded" v-bind:partner="partner"/>
       </v-container>
       <v-card-actions>
         <v-layout justify-space-between>
           <v-bpa-button color="secondary" to="/app/partners">
-            {{ $t("button.cancel") }}</v-bpa-button
+            {{ $t("button.cancel") }}
+          </v-bpa-button
           >
 
           <v-bpa-button v-if="!partnerLoaded" color="primary" @click="lookup()">
-            {{ $t("view.addPartner.lookupPartnerBtnLabel") }}</v-bpa-button
+            {{ $t("view.addPartner.lookupPartnerBtnLabel") }}
+          </v-bpa-button
           >
           <v-bpa-button v-else color="primary" @click="addPartner()">{{
-            $t("view.addPartner.addPartnerBtnLabel")
-          }}</v-bpa-button>
+              $t("view.addPartner.addPartnerBtnLabel")
+            }}
+          </v-bpa-button>
         </v-layout>
       </v-card-actions>
     </v-card>
@@ -110,9 +114,10 @@
 
 <script>
 import Profile from "@/components/Profile";
-import { EventBus } from "../main";
+import {EventBus} from "@/main";
 import VBpaButton from "@/components/BpaButton";
 import store from "@/store";
+
 export default {
   name: "AddPartner",
   components: {
@@ -127,6 +132,7 @@ export default {
       msg: "",
       did: "",
       alias: "",
+      aliasPlaceholder: "",
       partner: {},
       search: "",
       selectedTags: [],
@@ -156,7 +162,7 @@ export default {
             let partner = result.data;
             if ({}.hasOwnProperty.call(partner, "credential")) {
               this.partner = partner;
-              this.alias = partner.name;
+              this.aliasPlaceholder = partner.name;
               if ({}.hasOwnProperty.call(partner, "credential"))
                 this.partnerLoaded = true;
             } else if (partner.ariesSupport) {


### PR DESCRIPTION
Currently when we add a new Partner the Partners name is always pre filled with the partners legal name (if set). This can cause confusion because like this the partners alias is always set as well. For example:

1. agent 1 adds a new partner with legal name foo
2. partner changes legal name to bar
3. agent 1 reloads partner, legal name changes to bar, display name stays foo

This is totally correct as this adheres to our partner name strategy, but it is very confusing to the user. So instead of using two way binding to set the alias I only set the placeholder like this,

<img width="721" alt="Screen Shot 2021-08-11 at 16 34 47" src="https://user-images.githubusercontent.com/13498217/129050143-c6d76c08-8f05-45dd-9c2c-3ad1452c5c61.png">

then the user can set a real alias if needed.

<img width="696" alt="Screen Shot 2021-08-11 at 16 34 56" src="https://user-images.githubusercontent.com/13498217/129050188-46935d9c-7408-4c0a-945d-2faf40de94cf.png">


<a href="https://gitpod.io/#https://github.com/hyperledger-labs/business-partner-agent/pull/569"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

