### PR TITLE
Refactor 1 of Credential Management screen layout, prep for refactor 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ frontend/licenses/**
 **/application-dev-*.yml
 node_modules
 package-lock.json
+**/*.local
 
 # --------------------------------------
 # K8s / helm

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -23,7 +23,7 @@
     "dashboard": "Dashboard",
     "profile": "Public Profile",
     "wallet": "Wallet",
-    "credentialManagement": "Credential Management",
+    "credentialManagement": "Issue Credentials",
     "partners": "Business Partners",
     "settings": "Settings",
     "notifications": "Notifications",
@@ -103,6 +103,20 @@
       "createInvitation": "Generate Invitation (QR Code)",
       "invitationURL": "Invitation URL",
       "useOOB": "Use Out of Band"
+    },
+    "issueCredentials": {
+      "title": "Issue Credentials",
+      "cards": {
+        "action" : {
+          "title": "Issue Credential",
+          "button": "Issue Credential",
+          "partnerLabel": "Select partner...",
+          "credentialLabel": "Select credential..."
+        },
+        "table" : {
+          "title": "Issued Credentials"
+        }
+      }
     }
   },
   "constants": {

--- a/frontend/src/views/issuer/CredentialManagement.vue
+++ b/frontend/src/views/issuer/CredentialManagement.vue
@@ -8,45 +8,87 @@
 <template>
   <v-container>
     <v-card class="my-4">
-      <v-card-title class="bg-light"
-        >Schemas for Issuing Credentials</v-card-title
-      >
-      <v-card-text>
-        <SchemaList
-          :manage-credential-definitions="true"
-          :manage-trusted-issuers="false"
-          @changed="onSchemasChanged"
-        />
-      </v-card-text>
+      <v-card-title class="bg-light">{{$t("view.issueCredentials.cards.action.title")}}</v-card-title>
       <v-card-actions>
         <v-layout align-end justify-end>
-          <v-dialog v-model="createSchemaDialog" persistent max-width="600px">
+          <v-autocomplete
+              label="Select partner"
+              v-model="partner"
+              :items="partners"
+              return-object
+              class="mx-4"
+              flat
+              single-line
+              hide-no-data
+              hide-details
+              dense
+              outlined
+              clearable
+              clear-icon="$vuetify.icons.delete"
+          >
+            <template v-slot:item="data">
+              <v-icon
+                  x-small
+                  class="ml-2 mr-2"
+                  :color="partnerStateColor(data.item)"
+              >$vuetify.icons.partnerState</v-icon
+              >
+              {{ data.item.text }}
+            </template>
+            <template v-slot:selection="data">
+              <v-icon
+                  x-small
+                  class="ml-2 mr-2"
+                  :color="partnerStateColor(data.item)"
+              >$vuetify.icons.partnerState</v-icon
+              >
+              {{ data.item.text }}
+            </template>
+          </v-autocomplete>
+          <v-autocomplete
+              label="Select credential"
+              v-model="credDef"
+              :items="credDefs"
+              return-object
+              class="mx-4"
+              flat
+              single-line
+              hide-no-data
+              hide-details
+              dense
+              outlined
+              clearable
+              clear-icon="$vuetify.icons.delete"
+          ></v-autocomplete>
+          <v-dialog
+              v-model="issueCredentialDialog"
+              persistent
+              max-width="600px"
+          >
             <template v-slot:activator="{ on, attrs }">
-              <v-bpa-button v-bind="attrs" v-on="on" color="secondary"
-                >Create Schema</v-bpa-button
+              <v-bpa-button
+                  v-bind="attrs"
+                  v-on="on"
+                  color="primary"
+                  :disabled="issueCredentialDisabled"
+              >Issue Credential</v-bpa-button
               >
             </template>
-            <CreateSchema
-              @success="onSchemaCreated"
-              @cancelled="createSchemaDialog = false"
-            />
-          </v-dialog>
-          <v-dialog v-model="addSchemaDialog" persistent max-width="600px">
-            <template v-slot:activator="{ on, attrs }">
-              <v-bpa-button v-bind="attrs" v-on="on" color="primary"
-                >Import Schema</v-bpa-button
-              >
-            </template>
-            <AddSchema
-              @success="onSchemaAdded"
-              @cancelled="addSchemaDialog = false"
-            />
+            <IssueCredential
+                :credDefId="credDefId"
+                :partnerId="partnerId"
+                :credDefList="credDefs"
+                :partnerList="partners"
+                @success="credentialIssued"
+                @cancelled="issueCredentialDialog = false"
+            >
+            </IssueCredential>
           </v-dialog>
         </v-layout>
       </v-card-actions>
     </v-card>
     <v-card class="my-4">
-      <v-card-title class="bg-light">Issued Credentials</v-card-title>
+      <v-card-title class="bg-light">{{$t("view.issueCredentials.cards.table.title")}}</v-card-title>
       <v-card-text>
         <CredExList
           :items="issuedCredentials"
@@ -54,81 +96,6 @@
         ></CredExList>
       </v-card-text>
       <v-card-actions>
-        <v-layout align-end justify-end>
-          <v-autocomplete
-            label="Select partner"
-            v-model="partner"
-            :items="partners"
-            return-object
-            class="mx-4"
-            flat
-            single-line
-            hide-no-data
-            hide-details
-            dense
-            outlined
-            clearable
-            clear-icon="$vuetify.icons.delete"
-          >
-            <template v-slot:item="data">
-              <v-icon
-                x-small
-                class="ml-2 mr-2"
-                :color="partnerStateColor(data.item)"
-                >$vuetify.icons.partnerState</v-icon
-              >
-              {{ data.item.text }}
-            </template>
-            <template v-slot:selection="data">
-              <v-icon
-                x-small
-                class="ml-2 mr-2"
-                :color="partnerStateColor(data.item)"
-                >$vuetify.icons.partnerState</v-icon
-              >
-              {{ data.item.text }}
-            </template>
-          </v-autocomplete>
-          <v-autocomplete
-            label="Select credential"
-            v-model="credDef"
-            :items="credDefs"
-            return-object
-            class="mx-4"
-            flat
-            single-line
-            hide-no-data
-            hide-details
-            dense
-            outlined
-            clearable
-            clear-icon="$vuetify.icons.delete"
-          ></v-autocomplete>
-          <v-dialog
-            v-model="issueCredentialDialog"
-            persistent
-            max-width="600px"
-          >
-            <template v-slot:activator="{ on, attrs }">
-              <v-bpa-button
-                v-bind="attrs"
-                v-on="on"
-                color="primary"
-                :disabled="issueCredentialDisabled"
-                >Issue Credential</v-bpa-button
-              >
-            </template>
-            <IssueCredential
-              :credDefId="credDefId"
-              :partnerId="partnerId"
-              :credDefList="credDefs"
-              :partnerList="partners"
-              @success="credentialIssued"
-              @cancelled="issueCredentialDialog = false"
-            >
-            </IssueCredential>
-          </v-dialog>
-        </v-layout>
       </v-card-actions>
     </v-card>
   </v-container>
@@ -137,28 +104,21 @@
 <script>
 import { EventBus } from "@/main";
 import { issuerService, partnerService } from "@/services";
-import AddSchema from "@/components/AddSchema";
-import CreateSchema from "@/components/CreateSchema";
 import CredExList from "@/components/CredExList";
 import IssueCredential from "@/components/IssueCredential";
-import SchemaList from "@/components/SchemaList";
 import * as textUtils from "@/utils/textUtils";
 import * as partnerUtils from "@/utils/partnerUtils";
-import store from "@/store";
 import VBpaButton from "@/components/BpaButton";
 
 export default {
   name: "CredentialManagement",
   components: {
     VBpaButton,
-    SchemaList,
-    AddSchema,
-    CreateSchema,
     IssueCredential,
     CredExList,
   },
   created() {
-    EventBus.$emit("title", "Credential Management");
+    EventBus.$emit("title", this.$t("view.issueCredentials.title"));
     this.loadCredentials();
   },
   data: () => {
@@ -240,18 +200,6 @@ export default {
     credentialIssued() {
       this.issueCredentialDialog = false;
       this.loadCredentials();
-    },
-    onSchemaAdded() {
-      store.dispatch("loadSchemas");
-      this.addSchemaDialog = false;
-    },
-    onSchemaCreated() {
-      store.dispatch("loadSchemas");
-      this.createSchemaDialog = false;
-    },
-    onSchemasChanged() {
-      // rebuild the cred defs
-      this.loadCredDefs();
     },
   },
 };


### PR DESCRIPTION
This is just an initial PR to remove the duplicated Schema/Cred Def management from Credential Management.

This was confusing users to the real purpose of the screen which is to Issue Credentials.
So, renaming titles to Issue Credentials, remove the schema table, and move the Issuance action of the screen to the top of the screen.

There will be a subsequent PR to finish of the refactor (rename VUE files and paths, add in more resource based labels/naming). Holding off for now as there is another big PR that will hit the same code; just making it easier for that merge.


Signed-off-by: Jason Sherman <jsherman@parcsystems.ca>

<a href="https://gitpod.io/#https://github.com/hyperledger-labs/business-partner-agent/pull/575"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

