### PR TITLE
bugfix: proof template view/create pages not loading on refresh

### DIFF
--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/controller/ProofTemplateController.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/controller/ProofTemplateController.java
@@ -55,6 +55,16 @@ public class ProofTemplateController {
                         .collect(Collectors.toList()));
     }
 
+    @Get("/{id}")
+    public HttpResponse<ProofTemplate> getProofTemplateForId(@PathVariable @ValidUUID @NotNull String id) {
+        Optional<BPAProofTemplate> proofTemplate = proofTemplateManager.getProofTemplate(UUID.fromString(id));
+        if(proofTemplate.isPresent()){
+            return HttpResponse.ok(proofTemplate.get().toRepresentation());
+        } else {
+            return HttpResponse.notFound();
+        }
+    }
+
     @Post
     public HttpResponse<ProofTemplate> addProofTemplate(@Valid @Body ProofTemplate template) {
         if (template.getId() == null) {

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/ProofTemplateManager.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/ProofTemplateManager.java
@@ -52,6 +52,10 @@ public class ProofTemplateManager {
         proofTemplate.orElseThrow(() -> new ProofTemplateException("No proof template found for: " + id));
     }
 
+    public Optional<BPAProofTemplate> getProofTemplate(UUID id) {
+        return repo.findById(id);
+    }
+
     public BPAProofTemplate addProofTemplate(BPAProofTemplate template) {
         return repo.save(template);
     }

--- a/frontend/src/services/proofTemplateService.js
+++ b/frontend/src/services/proofTemplateService.js
@@ -13,6 +13,14 @@ export default {
   getProofTemplates() {
     return appAxios().get(`${ApiRoutes.PROOF_TEMPLATES}`);
   },
+  getProofTemplate(id) {
+    return appAxios().get(`${ApiRoutes.PROOF_TEMPLATES}/${id}`);
+  },
+  getKnownConditionOperators() {
+    return appAxios().get(
+      `${ApiRoutes.PROOF_TEMPLATES}/known-condition-operators`
+    );
+  },
   createProofTemplate(data) {
     return appAxios().post(`${ApiRoutes.PROOF_TEMPLATES}`, data);
   },

--- a/frontend/src/views/ProofTemplateCreate.vue
+++ b/frontend/src/views/ProofTemplateCreate.vue
@@ -362,21 +362,13 @@ export default {
     EventBus.$emit("title", "Proof Templates");
   },
   mounted() {
-    // load schemas
-    this.schemas = this.$store.getters.getSchemas.filter(
-      (schema) => schema.type === "INDY"
-    );
-
     // load condition operators (>, <, ==, etc)
-    this.$axios
-      .get(`${this.$apiBaseUrl}/proof-templates/known-condition-operators`)
-      .then((result) => {
-        this.operators = result.data;
-      });
+    proofTemplateService.getKnownConditionOperators().then((result) => {
+      this.operators = result.data;
+    });
   },
   data: () => {
     return {
-      schemas: [],
       operators: [],
       proofTemplate: {
         name: "",
@@ -384,7 +376,13 @@ export default {
       },
     };
   },
-  computed: {},
+  computed: {
+    schemas() {
+      return this.$store.getters.getSchemas.filter(
+        (schema) => schema.type === "INDY"
+      );
+    },
+  },
   watch: {},
   methods: {
     addAttributeGroup(schemaId) {

--- a/frontend/src/views/ProofTemplateView.vue
+++ b/frontend/src/views/ProofTemplateView.vue
@@ -251,36 +251,32 @@ export default {
   },
   created() {
     EventBus.$emit("title", "Proof Templates");
-    this.getProofTemplate();
   },
   data: () => {
     return {
-      schemas: [],
+      proofTemplate: {},
     };
   },
   mounted() {
-    // load schemas
-    this.schemas = this.$store.getters.getSchemas.filter(
-      (schema) => schema.type === "INDY"
-    );
+    proofTemplateService.getProofTemplate(this.id).then((result) => {
+      this.proofTemplate = result.data;
+    });
   },
-  computed: {},
+  computed: {
+    schemas() {
+      return this.$store.getters.getSchemas.filter(
+        (schema) => schema.type === "INDY"
+      );
+    },
+  },
   watch: {},
   methods: {
-    getProofTemplate() {
-      this.proofTemplate = this.$store.state.proofTemplates.find(
-        (pt) => pt.id === this.id
-      );
-      console.log("found: {}", JSON.stringify(this.proofTemplate));
-    },
     deleteProofTemplate() {
       proofTemplateService
         .deleteProofTemplate(this.proofTemplate.id)
         .then((result) => {
-          console.log(result);
           if (result.status === 200) {
             EventBus.$emit("success", "Proof Template Deleted");
-
             this.$router.push({
               name: "ProofTemplates",
               params: {},


### PR DESCRIPTION
When refreshing the proof template view & create pages manually, some fields were not being loaded due to the state/store variables being loaded asynchronously.  I corrected the code to accurately hook into the state lifecycle via the ```computed``` hook and provided a backed ```REST``` endpoint for getting a ```proof-template``` via an ID to make the endpoint fully CRUD.  

<a href="https://gitpod.io/#https://github.com/hyperledger-labs/business-partner-agent/pull/576"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

