### PR TITLE
Dashboard Update - more cards, get counts from backend.

### DIFF
--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/controller/api/stats/BPAStats.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/controller/api/stats/BPAStats.java
@@ -27,14 +27,14 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class BPAStats {
-    /** my DID */
+    /**
+     * my DID
+     */
     private String did;
-    /** If organization profile is already there */
+    /**
+     * If organization profile is already there
+     */
     private Boolean profile;
-    /** Number of partners */
-    private Long partners;
-    /** Number of credentials */
-    private Long credentials;
 
     private DashboardCounts totals;
     private DashboardCounts periodTotals;

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/controller/api/stats/DashboardCounts.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/controller/api/stats/DashboardCounts.java
@@ -26,16 +26,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class BPAStats {
-    /** my DID */
-    private String did;
-    /** If organization profile is already there */
-    private Boolean profile;
-    /** Number of partners */
-    private Long partners;
-    /** Number of credentials */
-    private Long credentials;
+public class DashboardCounts {
 
-    private DashboardCounts totals;
-    private DashboardCounts periodTotals;
+    private Long credentialsSent;
+    private Long credentialsReceived;
+    private Long presentationRequestsSent;
+    private Long presentationRequestsReceived;
+    private Long partners;
+    private Long tasks;
 }

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/StatsService.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/StatsService.java
@@ -91,8 +91,6 @@ public class StatsService {
                 .did(identity.getMyDid())
                 .profile(docRepo
                         .existsByTypeEqualsAndIsPublicTrue(CredentialType.ORGANIZATIONAL_PROFILE_CREDENTIAL))
-                .partners(partnerRepo.count())
-                .credentials(credRepo.countByStateEquals(CredentialExchangeState.CREDENTIAL_ACKED))
                 .totals(totals)
                 .periodTotals(periodTotals)
                 .build();

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/StatsService.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/StatsService.java
@@ -19,15 +19,17 @@ package org.hyperledger.bpa.impl;
 
 import lombok.extern.slf4j.Slf4j;
 import org.hyperledger.aries.api.issue_credential_v1.CredentialExchangeState;
+import org.hyperledger.aries.api.present_proof.PresentationExchangeState;
 import org.hyperledger.bpa.api.CredentialType;
 import org.hyperledger.bpa.controller.api.stats.BPAStats;
+import org.hyperledger.bpa.controller.api.stats.DashboardCounts;
 import org.hyperledger.bpa.impl.activity.Identity;
-import org.hyperledger.bpa.repository.MyCredentialRepository;
-import org.hyperledger.bpa.repository.MyDocumentRepository;
-import org.hyperledger.bpa.repository.PartnerRepository;
+import org.hyperledger.bpa.repository.*;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 
 @Slf4j
 @Singleton
@@ -45,7 +47,45 @@ public class StatsService {
     @Inject
     Identity identity;
 
+    @Inject
+    BPACredentialExchangeRepository credExRepo;
+
+    @Inject
+    ActivityRepository activityRepository;
+
+    @Inject
+    PartnerProofRepository proofRepository;
+
     public BPAStats collectStats() {
+        DashboardCounts totals = DashboardCounts
+                .builder()
+                .credentialsSent(credExRepo.countByStateEquals(CredentialExchangeState.CREDENTIAL_ACKED))
+                .credentialsReceived(credRepo.countByStateEquals(CredentialExchangeState.CREDENTIAL_ACKED))
+                .tasks(activityRepository.countByCompletedFalse())
+                .partners(partnerRepo.count())
+                .presentationRequestsSent(proofRepository.countByStateEquals(PresentationExchangeState.REQUEST_SENT))
+                .presentationRequestsReceived(
+                        proofRepository.countByStateEquals(PresentationExchangeState.PRESENTATION_RECEIVED))
+                .build();
+
+        // for now, let's just get new data created today.
+        // we could maybe pass in a date from the ux for different filter/period (last
+        // week, last month, ???)
+        Instant yesterday = Instant.now().minus(1, ChronoUnit.DAYS);
+        DashboardCounts periodTotals = DashboardCounts
+                .builder()
+                .credentialsSent(credExRepo
+                        .countByStateEqualsAndCreatedAtAfter(CredentialExchangeState.CREDENTIAL_ACKED, yesterday))
+                .credentialsReceived(credRepo
+                        .countByStateEqualsAndIssuedAtAfter(CredentialExchangeState.CREDENTIAL_ACKED, yesterday))
+                .tasks(activityRepository.countByCompletedFalseAndCreatedAtAfter(yesterday))
+                .partners(partnerRepo.countByCreatedAtAfter(yesterday))
+                .presentationRequestsSent(proofRepository
+                        .countByStateEqualsAndCreatedAtAfter(PresentationExchangeState.REQUEST_SENT, yesterday))
+                .presentationRequestsReceived(proofRepository.countByStateEqualsAndCreatedAtAfter(
+                        PresentationExchangeState.PRESENTATION_RECEIVED, yesterday))
+                .build();
+
         return BPAStats
                 .builder()
                 .did(identity.getMyDid())
@@ -53,6 +93,8 @@ public class StatsService {
                         .existsByTypeEqualsAndIsPublicTrue(CredentialType.ORGANIZATIONAL_PROFILE_CREDENTIAL))
                 .partners(partnerRepo.count())
                 .credentials(credRepo.countByStateEquals(CredentialExchangeState.CREDENTIAL_ACKED))
+                .totals(totals)
+                .periodTotals(periodTotals)
                 .build();
     }
 }

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/model/ChatMessage.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/model/ChatMessage.java
@@ -26,10 +26,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 import java.time.Instant;
 import java.util.UUID;
 
@@ -57,7 +54,7 @@ public class ChatMessage {
     private Instant createdAt;
 
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
-    public Long getCreatedAtTs() {
+    public Long createdAtTs() {
         return this.createdAt.toEpochMilli();
     }
 }

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/repository/ActivityRepository.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/repository/ActivityRepository.java
@@ -26,6 +26,7 @@ import org.hyperledger.bpa.controller.api.activity.ActivityRole;
 import org.hyperledger.bpa.controller.api.activity.ActivityType;
 import org.hyperledger.bpa.model.Activity;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -70,4 +71,8 @@ public interface ActivityRepository extends CrudRepository<Activity, UUID> {
     List<Activity> findByTypeAndCompletedTrueOrderByUpdatedAtDesc(@NonNull ActivityType type);
 
     void deleteByPartnerId(@NonNull UUID partnerId);
+
+    Long countByCompletedFalse();
+
+    Long countByCompletedFalseAndCreatedAtAfter(Instant createdAt);
 }

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/repository/BPACredentialExchangeRepository.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/repository/BPACredentialExchangeRepository.java
@@ -23,8 +23,10 @@ import io.micronaut.data.annotation.Join;
 import io.micronaut.data.jdbc.annotation.JdbcRepository;
 import io.micronaut.data.model.query.builder.sql.Dialect;
 import io.micronaut.data.repository.CrudRepository;
+import org.hyperledger.aries.api.issue_credential_v1.CredentialExchangeState;
 import org.hyperledger.bpa.model.BPACredentialExchange;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -57,4 +59,9 @@ public interface BPACredentialExchangeRepository extends CrudRepository<BPACrede
     List<BPACredentialExchange> listOrderByUpdatedAtDesc();
 
     int updateRevoked(@Id UUID id, Boolean revoked);
+
+    Long countByStateEquals(CredentialExchangeState state);
+
+    Long countByStateEqualsAndCreatedAtAfter(CredentialExchangeState state, Instant createdAt);
+
 }

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/repository/MyCredentialRepository.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/repository/MyCredentialRepository.java
@@ -26,6 +26,7 @@ import io.micronaut.data.repository.CrudRepository;
 import org.hyperledger.aries.api.issue_credential_v1.CredentialExchangeState;
 import org.hyperledger.bpa.model.MyCredential;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -54,6 +55,8 @@ public interface MyCredentialRepository extends CrudRepository<MyCredential, UUI
     List<MyCredential> findBySchemaIdAndCredentialDefinitionId(String schemaId, String credentialDefinitionId);
 
     Long countByStateEquals(CredentialExchangeState state);
+
+    Long countByStateEqualsAndIssuedAtAfter(CredentialExchangeState state, Instant issuedAt);
 
     @Query("SELECT * FROM my_credential WHERE type = 'INDY' AND referent IS NOT NULL AND (revoked IS NULL OR revoked = false)")
     List<MyCredential> findNotRevoked();

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/repository/PartnerProofRepository.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/repository/PartnerProofRepository.java
@@ -71,4 +71,7 @@ public interface PartnerProofRepository extends CrudRepository<PartnerProof, UUI
 
     Iterable<PartnerProof> findByStateIn(List<PresentationExchangeState> states);
 
+    Long countByStateEquals(PresentationExchangeState state);
+
+    Long countByStateEqualsAndCreatedAtAfter(PresentationExchangeState state, Instant createdAt);
 }

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/repository/PartnerRepository.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/repository/PartnerRepository.java
@@ -91,4 +91,5 @@ public interface PartnerRepository extends CrudRepository<Partner, UUID> {
 
     Iterable<Partner> findByStateIn(List<ConnectionState> states);
 
+    Long countByCreatedAtAfter(Instant createdAt);
 }

--- a/frontend/src/assets/scss/style.scss
+++ b/frontend/src/assets/scss/style.scss
@@ -83,6 +83,49 @@ a {
   }
 }
 
+.dashboard-card {
+  .card-title {
+    font-size: 1.25rem !important;
+  }
+
+  // applied when using a non-svg icon (from font awesome)
+  .graphic {
+    height: 180px;
+    width: 180px;
+    font-size: 180px !important;
+    color: black !important;
+  }
+
+  // applied when using an svg icon (material design)
+  .v-icon__svg {
+    font-size: 180px;
+    height: 180px;
+    width: 180px;
+    color: black;
+  }
+
+  // font size need to account for 3 number characters (ex 100).
+  .count {
+    height: 120px;
+    line-height: 120px;
+    font-size: 110px;
+    color: black;
+  }
+
+  .new-count {
+    height: 30px;
+    line-height: 30px;
+    font-size: 25px;
+    color: #2ecc71;
+  }
+
+  a {
+    &:hover {
+      text-decoration: none;
+    }
+  }
+}
+
 // buttons in v-card
 .v-card__actions > .v-btn {
   padding: 0 16px !important;
@@ -104,12 +147,6 @@ nav {
     &:hover {
       text-decoration: none;
     }
-  }
-}
-
-a.dashboard-card {
-  &:hover {
-    text-decoration: none;
   }
 }
 
@@ -176,5 +213,117 @@ div {
     margin-top: -4px;
     margin-bottom: 4px;
     margin-right: 4px;
+  }
+}
+
+// dashboard text and icon resizing...
+// lg 1264px > < 1904
+// md 960px > < 1264px
+// sm
+@media (min-width: 1360px) and (max-width: 1904px) {
+  .dashboard-card {
+    .card-title {
+      font-size: 1rem !important;
+    }
+    // applied when using a non-svg icon (from font awesome)
+    .graphic {
+      height: 120px;
+      width: 120px;
+      font-size: 120px !important;
+    }
+
+    // applied when using an svg icon (material design)
+    .v-icon__svg {
+      font-size: 120px;
+      height: 120px;
+      width: 120px;
+    }
+
+    .count {
+      height: 100px;
+      line-height: 100px;
+      font-size: 60px;
+    }
+
+    .new-count {
+      height: 20px;
+      line-height: 20px;
+      font-size: 20px;
+    }
+  }
+}
+
+@media (min-width: 1264px) and (max-width: 1360px) {
+  .dashboard-card {
+    .card-title {
+      font-size: 1rem !important;
+    }
+    // applied when using a non-svg icon (from font awesome)
+    .graphic {
+      height: 120px;
+      width: 120px;
+      font-size: 120px !important;
+    }
+
+    // applied when using an svg icon (material design)
+    .v-icon__svg {
+      font-size: 120px;
+      height: 120px;
+      width: 120px;
+    }
+
+    // font size need to account for 3 number characters (ex 100).
+    .count {
+      height: 100px;
+      line-height: 100px;
+      font-size: 50px;
+    }
+
+    .new-count {
+      height: 20px;
+      line-height: 20px;
+      font-size: 20px;
+    }
+  }
+}
+@media (max-width: 1264px) {
+  .dashboard-card {
+    .card-title {
+      font-size: 1rem !important;
+    }
+    // applied when using a non-svg icon (from font awesome)
+    .graphic {
+      height: 120px;
+      width: 120px;
+      font-size: 120px !important;
+    }
+
+    // applied when using an svg icon (material design)
+    .v-icon__svg {
+      font-size: 120px;
+      height: 120px;
+      width: 120px;
+    }
+
+    // font size need to account for 3 number characters (ex 100).
+    .count {
+      height: 100px;
+      line-height: 100px;
+      font-size: 40px;
+    }
+
+    .new-count {
+      height: 20px;
+      line-height: 20px;
+      font-size: 20px;
+    }
+  }
+}
+@media (min-width: 960px) and (max-width: 1264px) {
+  .dashboard-card {
+    // just need it a little smaller until we collapse our columns from 3 to 2.
+    .card-title {
+      font-size: .85rem !important;
+    }
   }
 }

--- a/frontend/src/components/DashboardCard.vue
+++ b/frontend/src/components/DashboardCard.vue
@@ -1,0 +1,75 @@
+<!--
+ Copyright (c) 2020 - for information on the respective copyright owner
+ see the NOTICE file and/or the repository at
+ https://github.com/hyperledger-labs/organizational-agent
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+<template>
+  <v-card class="mx-auto dashboard-card">
+    <v-card-title class="justify-center bg-light card-title" style="text-transform: capitalize">{{this.title}}</v-card-title>
+    <v-card-text>
+      <v-container>
+        <v-row>
+          <v-col class="col-6">
+            <div class="container"><v-icon class="graphic">{{this.icon}}</v-icon></div>
+          </v-col>
+          <v-col class="col-6">
+            <div class="container">
+              <v-row>
+                <v-col class="count">{{this.count}}</v-col>
+              </v-row>
+              <v-row>
+                <v-col class="new-count">{{this.newCountDisplay}}</v-col>
+              </v-row>
+            </div>
+          </v-col>
+        </v-row>
+      </v-container>
+    </v-card-text>
+    <v-card-actions class="justify-center">
+      <v-btn icon :to="{ name: this.destination }"><v-icon color="primary">$vuetify.icons.dashboardGo</v-icon></v-btn>
+    </v-card-actions>
+  </v-card>
+</template>
+
+<script>
+
+  export default {
+    name: "DashboardCard",
+    components: { },
+    props: {
+      title: {
+        type: String,
+        default: () => "Title"
+      },
+      icon: {
+        type: String,
+        default: () => "$vuetify.icons.user"
+      },
+      destination: {
+        type: String,
+        default: () => "Dashboard"
+      },
+      count: {
+        type: Number,
+        default: () => 0
+      },
+      newCount: {
+        type: Number,
+        default: () => 0
+      },
+    },
+    created() {
+    },
+    data: () => {
+      return { };
+    },
+    computed: {
+      newCountDisplay() {
+        return (this.newCount) ? `(+ ${this.newCount})`: "";
+      },
+    },
+    methods: { },
+  };
+</script>

--- a/frontend/src/components/DashboardCard.vue
+++ b/frontend/src/components/DashboardCard.vue
@@ -28,7 +28,8 @@
       </v-container>
     </v-card-text>
     <v-card-actions class="justify-center">
-      <v-btn icon :to="{ name: this.destination }"><v-icon color="primary">$vuetify.icons.dashboardGo</v-icon></v-btn>
+      <v-btn v-if="this.destination" icon :to="{ name: this.destination }"><v-icon color="primary">$vuetify.icons.dashboardGo</v-icon></v-btn>
+      <v-btn v-else icon disabled><!-- this is only in place to keep the size of the cards consistent --></v-btn>
     </v-card-actions>
   </v-card>
 </template>
@@ -49,7 +50,7 @@
       },
       destination: {
         type: String,
-        default: () => "Dashboard"
+        default: () => null
       },
       count: {
         type: Number,

--- a/frontend/src/locales/bcgov.json
+++ b/frontend/src/locales/bcgov.json
@@ -1,4 +1,12 @@
 {
+  "dashboard": {
+    "credentialsSent": "Credentials You Issued",
+    "credentialsReceived": "Credentials You Hold",
+    "presentationRequestsSent": "Sent Proof Requests",
+    "presentationRequestsReceived": "Received Proof Requests",
+    "partners": "Business Partners",
+    "tasks": "Pending Tasks"
+  },
   "view": {
     "partner": {
       "receivedPresentations": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -31,6 +31,14 @@
     "signout": "Sign out",
     "proofTemplates": "Proof Templates"
   },
+  "dashboard": {
+    "credentialsSent": "Credentials Issued",
+    "credentialsReceived": "Credentials in Wallet",
+    "presentationRequestsSent": "Presentation Requests Sent",
+    "presentationRequestsReceived": "Presentation Requests Received",
+    "partners": "Business Partners",
+    "tasks": "Pending Tasks"
+  },
   "button" : {
     "save": "Save",
     "submit": "Submit",

--- a/frontend/src/plugins/vuetify.js
+++ b/frontend/src/plugins/vuetify.js
@@ -84,7 +84,8 @@ export default new Vuetify({
       save: mdiContentSave,
       chat: mdiMessageText,
       revoke: mdiBook,
-      revoked: mdiBookRemove
+      revoked: mdiBookRemove,
+      dashboardGo: "fas fa-arrow-alt-circle-right"
     },
   },
   theme: {

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -10,72 +10,77 @@
     <div v-if="isWelcome && !isLoading">
       <!-- Image from undraw.co -->
       <v-img
-        class="mx-auto"
-        src="@/assets/undraw_welcome_3gvl_grey.png"
-        max-width="300"
-        aspect-ratio="1"
+          class="mx-auto"
+          src="@/assets/undraw_welcome_3gvl_grey.png"
+          max-width="300"
+          aspect-ratio="1"
       ></v-img>
       <p
-        v-bind:style="{ fontSize: `180%` }"
-        class="grey--text text--darken-2 font-weight-medium"
+          v-bind:style="{ fontSize: `180%` }"
+          class="grey--text text--darken-2 font-weight-medium"
       >
         Hi, we've already set up an identity for you!
       </p>
       <!-- <p v-bind:style="{ fontSize: `140%` }" class="grey--text text--darken-2 font-weight-medium">Start by adding a public profile that your business partners will see</p> -->
       <br />
       <v-bpa-button
-        color="primary"
-        :to="{
+          color="primary"
+          :to="{
           name: 'DocumentAdd',
           params: { type: CredentialTypes.PROFILE.type },
         }"
-        >Setup your Profile</v-bpa-button
+      >Setup your Profile</v-bpa-button
       >
     </div>
     <div v-if="!isWelcome && !isLoading">
       <v-row>
-        <v-col class="col-sm-5 offset-sm-1 col-md-4 offset-md-2">
-          <v-card class="mx-auto" :to="{ name: 'Wallet' }">
-            <v-img
-              class="align-end"
-              src="@/assets/undraw_certification_aif8.png"
-            ></v-img>
-            <v-card-title class="justify-center">
-              <span class="cardTitle">
-                {{ status.credentials }}
-              </span>
-              <span
-                class="newHighlight"
-                v-show="credentialNotificationsCount > 0"
-              >
-                (+{{ credentialNotificationsCount }})
-              </span>
-            </v-card-title>
-            <v-card-title class="justify-center"
-              >Verified Credentials</v-card-title
-            >
-          </v-card>
+        <v-col class="col-12 col-sm-6 col-md-4">
+          <dashboard-card
+              :title="$t('dashboard.credentialsReceived')"
+              icon=$vuetify.icons.wallet
+              :count=this.status.totals.credentialsReceived
+              :new-count=this.status.periodTotals.credentialsReceived
+              destination="Wallet"></dashboard-card>
         </v-col>
-        <v-col class="col-sm-5 col-md-4">
-          <v-card class="mx-auto" :to="{ name: 'Partners' }">
-            <!-- FIXME Used aspect ratio as a hacky way to make the cards the same height -->
-            <v-img
-              class="align-end"
-              aspect-ratio="1.29"
-              src="@/assets/undraw_agreement_aajr.png"
-            ></v-img>
-            <v-card-title class="justify-center">
-              <span class="cardTitle">
-                {{ status.partners }}
-              </span>
-              <span class="newHighlight" v-show="partnerNotificationsCount > 0">
-                (+{{ partnerNotificationsCount }})
-              </span>
-            </v-card-title>
-            <v-card-title class="justify-center"
-              >Business Partners</v-card-title
-            >
-          </v-card>
+        <v-col class="col-12 col-sm-6 col-md-4">
+          <dashboard-card
+              :title="$t('dashboard.presentationRequestsSent')"
+              icon=$vuetify.icons.proofRequests
+              :count=this.status.totals.presentationRequestsSent
+              :new-count=this.status.periodTotals.presentationRequestsSent
+              destination="Partners"></dashboard-card>
+        </v-col>
+        <v-col class="col-12 col-sm-6 col-md-4">
+          <dashboard-card
+              :title="$t('dashboard.partners')"
+              icon=$vuetify.icons.partners
+              :count=this.status.totals.partners
+              :new-count=this.status.periodTotals.partners
+              destination="Partners"></dashboard-card>
+        </v-col>
+        <v-col class="col-12 col-sm-6 col-md-4">
+          <dashboard-card
+              :title="$t('dashboard.credentialsSent')"
+              icon=$vuetify.icons.credentialManagement
+              :count=this.status.totals.credentialsSent
+              :new-count=this.status.periodTotals.credentialsSent
+              destination="CredentialManagement"></dashboard-card>
+        </v-col>
+        <v-col class="col-12 col-sm-6 col-md-4">
+          <dashboard-card
+              :title="$t('dashboard.presentationRequestsReceived')"
+              icon=$vuetify.icons.proofRequests
+              :count=this.status.totals.presentationRequestsReceived
+              :new-count=this.status.periodTotals.presentationRequestsReceived
+              destination="Partners"></dashboard-card>
+        </v-col>
+        <v-col class="col-12 col-sm-6 col-md-4">
+          <dashboard-card
+              :title="$t('dashboard.tasks')"
+              icon=$vuetify.icons.notifications
+              :count=this.status.totals.tasks
+              :new-count=this.status.periodTotals.tasks
+              destination="Notifications"></dashboard-card>
         </v-col>
       </v-row>
     </div>
@@ -83,59 +88,61 @@
 </template>
 
 <script>
-import { EventBus } from "../main";
-import { CredentialTypes } from "../constants";
-import VBpaButton from "@/components/BpaButton";
-export default {
-  name: "Dashboard",
-  components: { VBpaButton },
-  created() {
-    EventBus.$emit("title", "Dashboard");
-    this.getStatus();
-  },
-  data: () => {
-    return {
-      isWelcome: true,
-      isLoading: true,
-      CredentialTypes,
-    };
-  },
-  computed: {
-    partnerNotificationsCount() {
-      return this.$store.getters.partnerNotificationsCount;
+  import { EventBus } from "../main";
+  import { CredentialTypes } from "../constants";
+  import VBpaButton from "@/components/BpaButton";
+  import DashboardCard from "@/components/DashboardCard";
+
+  export default {
+    name: "Dashboard",
+    components: {DashboardCard, VBpaButton },
+    created() {
+      EventBus.$emit("title", "Dashboard");
+      this.getStatus();
     },
-    credentialNotificationsCount() {
-      return this.$store.getters.credentialNotificationsCount;
+    data: () => {
+      return {
+        isWelcome: true,
+        isLoading: true,
+        CredentialTypes,
+      };
     },
-  },
-  methods: {
-    getStatus() {
-      console.log("Getting status...");
-      this.$axios
-        .get(`${this.$apiBaseUrl}/status`)
-        .then((result) => {
-          console.log(result);
-          this.isWelcome = !result.data.profile;
-          this.status = result.data;
-          this.isLoading = false;
-        })
-        .catch((e) => {
-          console.error(e);
-          this.isLoading = false;
-          EventBus.$emit("error", e);
-        });
+    computed: {
+      partnerNotificationsCount() {
+        return this.$store.getters.partnerNotificationsCount;
+      },
+      credentialNotificationsCount() {
+        return this.$store.getters.credentialNotificationsCount;
+      },
     },
-  },
-};
+    methods: {
+      getStatus() {
+        console.log("Getting status...");
+        this.$axios
+          .get(`${this.$apiBaseUrl}/status`)
+          .then((result) => {
+            console.log(result);
+            this.isWelcome = !result.data.profile;
+            this.status = result.data;
+            this.isLoading = false;
+          })
+          .catch((e) => {
+            console.error(e);
+            this.isLoading = false;
+            EventBus.$emit("error", e);
+          });
+      },
+    },
+  };
 </script>
 <style scoped>
-.newHighlight {
-  color: #2ecc71;
-  padding-left: 4px;
-  font-size: 200%;
-}
-.cardTitle {
-  font-size: 400%;
-  margin-bottom: 2;
-}
+  .newHighlight {
+    color: #2ecc71;
+    padding-left: 4px;
+    font-size: 200%;
+  }
+  .cardTitle {
+    font-size: 400%;
+    margin-bottom: 2;
+  }
 </style>

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -47,8 +47,7 @@
               :title="$t('dashboard.presentationRequestsSent')"
               icon=$vuetify.icons.proofRequests
               :count=this.status.totals.presentationRequestsSent
-              :new-count=this.status.periodTotals.presentationRequestsSent
-              destination="Partners"></dashboard-card>
+              :new-count=this.status.periodTotals.presentationRequestsSent></dashboard-card>
         </v-col>
         <v-col class="col-12 col-sm-6 col-md-4">
           <dashboard-card
@@ -71,8 +70,7 @@
               :title="$t('dashboard.presentationRequestsReceived')"
               icon=$vuetify.icons.proofRequests
               :count=this.status.totals.presentationRequestsReceived
-              :new-count=this.status.periodTotals.presentationRequestsReceived
-              destination="Partners"></dashboard-card>
+              :new-count=this.status.periodTotals.presentationRequestsReceived></dashboard-card>
         </v-col>
         <v-col class="col-12 col-sm-6 col-md-4">
           <dashboard-card


### PR DESCRIPTION
Signed-off-by: Jason Sherman <jsherman@parcsystems.ca>

Refactor out a UX component for the cards, do some styling on different window sizes to keep text readable.
Get all counts (totals and "new" items) from backend for the dashboard. This will allow future enhancements to get counts for different periods, such as new items since yesterday (default) or last week or last month.



<a href="https://gitpod.io/#https://github.com/hyperledger-labs/business-partner-agent/pull/577"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

