### PR TITLE
Fix proof template view + other small fixes

### DIFF
--- a/frontend/src/components/PresentationExList.vue
+++ b/frontend/src/components/PresentationExList.vue
@@ -193,7 +193,6 @@ export default {
             return Object.hasOwnProperty.call(group, "selectedCredential");
           });
         });
-        console.log(groupsWithCredentials.flat().reduce((x, y) => x && y));
         return groupsWithCredentials.flat().reduce((x, y) => x && y);
       } else {
         return false;

--- a/frontend/src/components/proof-templates/AttributeGroup.vue
+++ b/frontend/src/components/proof-templates/AttributeGroup.vue
@@ -18,7 +18,7 @@
 
 <template>
   <v-container>
-    <v-expansion-panels>
+    <v-expansion-panels focusable>
       <v-expansion-panel
         class="my-5"
         v-for="(attributeGroup, idx) in requestData"
@@ -179,7 +179,7 @@ export default {
       }
 
       if (schema) {
-        return `<strong>${schema.label}</strong><i>&nbsp;(${schema.schemaId})</i>`;
+        return `<strong>${schema.label}</strong><em>&nbsp;(${schema.schemaId})</em>`;
       } else if (schemaId) {
         return schemaId;
       } else {

--- a/frontend/src/views/ProofTemplateCreate.vue
+++ b/frontend/src/views/ProofTemplateCreate.vue
@@ -52,7 +52,7 @@
           >
 
           <v-container>
-            <v-expansion-panels>
+            <v-expansion-panels focusable>
               <v-expansion-panel
                 class="my-5"
                 v-for="(attributeGroup, idx) in proofTemplate.attributeGroups"
@@ -407,7 +407,7 @@ export default {
       const schema = this.$store.getters.getSchemas.find(
         (s) => s.id === attributeGroup.schemaId
       );
-      return `${schema.label}<i>&nbsp;(${schema.schemaId})</i>`;
+      return `${schema.label}<em>&nbsp;(${schema.schemaId})</em>`;
     },
     addAttributeGroup(schemaId) {
       // add a blank attribute group template

--- a/frontend/src/views/ProofTemplateView.vue
+++ b/frontend/src/views/ProofTemplateView.vue
@@ -64,7 +64,7 @@
           <v-list-item-title>Data to be requested</v-list-item-title>
           <v-list-item-subtitle>Grouped by Schema </v-list-item-subtitle>
           <attribute-group
-            v-bind:data="proofTemplate.attributeGroups"
+            v-bind:request-data="proofTemplate.attributeGroups"
           ></attribute-group>
         </v-list-item-content>
       </v-list-item>

--- a/scripts/scenarios/local-network/docker-compose-linux.yml
+++ b/scripts/scenarios/local-network/docker-compose-linux.yml
@@ -6,7 +6,7 @@ services:
   bpa1:
     image: ghcr.io/hyperledger-labs/business-partner-agent:local
     build:
-      context: ../..
+      context: ../../..
       dockerfile: Dockerfile
     depends_on:
       - bpa-agent1
@@ -89,7 +89,7 @@ services:
 #######
   bpa2:
     build:
-      context: ../..
+      context: ../../..
       dockerfile: Dockerfile
     depends_on:
       -  bpa-agent2


### PR DESCRIPTION
Fix missing attribute groups when viewing a created Proof Template.
Added a couple of more small refactorings/fixes:

- local scenario: docker-compose context path
- changed cursive tags
- made panels focusable (styling)

<a href="https://gitpod.io/#https://github.com/hyperledger-labs/business-partner-agent/pull/595"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

