### PR TITLE
Chat Icon hides buttons

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -299,18 +299,18 @@
      <BasicMessages ref="basicMessages" />
     </div>
 
-    <v-footer v-if="showFooter" app>
+    <v-footer app>
       <v-col cols="12" class="text-center">
-        <span v-if="imprintUrl" class="mr-4 subtitle-2"
+        <span v-if="showFooter && imprintUrl" class="mr-4 subtitle-2"
           ><a :href="imprintUrl">{{
             $t("app.footer.imprintUrl.text")
           }}</a></span
-        >
-        <span v-if="privacyPolicyUrl" class="subtitle-2"
+        ><span v-else class="mr-4 subtitle-2">&nbsp;</span>
+        <span v-if="showFooter && privacyPolicyUrl" class="subtitle-2"
           ><a :href="privacyPolicyUrl">{{
             $t("app.footer.privacyPolicyUrl.text")
           }}</a></span
-        >
+        ><span v-else class="mr-4 subtitle-2">&nbsp;</span>
       </v-col>
     </v-footer>
   </v-app>


### PR DESCRIPTION
When no footer, and screen width is fairly narrow and there is a long form, the chat window hides the form buttons.
Simplest fix is to ALWAYS show the footer and that bumps up any buttons or interactions above the chat icon.


Signed-off-by: Jason Sherman <jsherman@parcsystems.ca>

<a href="https://gitpod.io/#https://github.com/hyperledger-labs/business-partner-agent/pull/598"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

