### PR TITLE
Cred Def - make Tag required (help with our display of cred defs).

### DIFF
--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/repository/BPACredentialDefinitionRepository.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/repository/BPACredentialDefinitionRepository.java
@@ -38,4 +38,7 @@ public interface BPACredentialDefinitionRepository extends CrudRepository<BPACre
     @Join(value = "schema", type = Join.Type.LEFT_FETCH)
     Optional<BPACredentialDefinition> findById(@NonNull UUID id);
 
+    @NonNull
+    Optional<BPACredentialDefinition> findByCredentialDefinitionId(@NonNull String credentialDefinitionId);
+
 }

--- a/frontend/src/components/CredentialDefinitions.vue
+++ b/frontend/src/components/CredentialDefinitions.vue
@@ -11,150 +11,173 @@
     <v-row v-for="(entry, index) in items" v-bind:key="index">
       <v-col cols="4" class="py-0">
         <v-text-field
-          label="Tag"
-          :disabled="!entry.isEdit"
-          v-model="entry.tag"
-          outlined
-          dense
+            label="Tag (required)"
+            :disabled="!entry.isEdit"
+            v-model="entry.tag"
+            :rules="[(v) => !!v || 'Tag is required']"
+            outlined
+            dense
         ></v-text-field>
       </v-col>
       <v-col class="py-0">
         <v-checkbox
-          class="mt-1"
-          label="Revocable"
-          v-model="entry.supportRevocation"
-          :disabled="!isTailsConfigured || !entry.isEdit"
-          outlined
-          dense
+            class="mt-1"
+            label="Revocable"
+            v-model="entry.supportRevocation"
+            :disabled="!isTailsConfigured || !entry.isEdit"
+            outlined
+            dense
         >
         </v-checkbox>
       </v-col>
       <v-col cols="3" class="py-0">
         <v-btn
-          v-if="!entry.id && entry.isEdit"
-          :loading="isBusy"
-          icon
-          @click="saveItem(entry)"
+            v-if="!entry.id && entry.isEdit"
+            :loading="isBusy"
+            :disabled="entry.tag && entry.tag.trim().length === 0"
+            icon
+            @click="saveItem(entry)"
         >
           <v-icon color="primary">$vuetify.icons.save</v-icon>
         </v-btn>
         <v-btn icon v-if="!entry.isEdit" @click="deleteItem(index)">
           <v-icon color="error">$vuetify.icons.delete</v-icon>
         </v-btn>
+        <v-btn icon v-if="!entry.id && entry.isEdit" @click="cancelSaveItem(index)">
+          <v-icon color="error">$vuetify.icons.cancel</v-icon>
+        </v-btn>
       </v-col>
     </v-row>
     <v-row>
       <v-bpa-button :disabled="isEdit" color="secondary" @click="addItem"
-        >Add Credential Definition</v-bpa-button
+      >Add Credential Definition</v-bpa-button
       >
     </v-row>
   </v-container>
 </template>
 
 <script>
-import { EventBus } from "@/main";
-import issuerService from "@/services/issuerService";
-import VBpaButton from "@/components/BpaButton";
+  import { EventBus } from "@/main";
+  import issuerService from "@/services/issuerService";
+  import VBpaButton from "@/components/BpaButton";
 
-export default {
-  components: { VBpaButton },
-  props: {
-    schema: {
-      type: Object,
-      default: () => {},
+  export default {
+    components: { VBpaButton },
+    props: {
+      schema: {
+        type: Object,
+        default: () => {},
+      },
+      credentialDefinitions: {
+        type: Array,
+        default: function () {
+          return [];
+        },
+      },
+      reset: {
+        type: Boolean,
+        default: () => false,
+      }
     },
-    credentialDefinitions: {
-      type: Array,
-      default: function () {
-        return [];
+    watch: {
+      schema() {
+        this.isEdit = false;
+        this.editingItem = false;
+      },
+      credentialDefinitions(val) {
+        this.items = Array.from(val);
+        this.isEdit = false;
+        this.editingItem = false;
+      },
+      reset(newVal, oldVal) {
+        // use this to reset the form, remove any outstanding items that are not saved.
+        if (newVal !== oldVal) {
+          this.items = Array.from(this.credentialDefinitions);
+          this.isEdit = false;
+          this.editingItem = false;
+        }
+      }
+    },
+    created() {},
+    mounted() {
+      this.items = Array.from(this.credentialDefinitions);
+    },
+    data: () => {
+      return {
+        items: [],
+        isEdit: false,
+        editingItem: null,
+        isBusy: false,
+      };
+    },
+    computed: {
+      isTailsConfigured() {
+        return this.$config.tailsServerConfigured;
       },
     },
-  },
-  watch: {
-    schema() {
-      this.isEdit = false;
-      this.editingItem = false;
-    },
-    credentialDefinitions(val) {
-      this.items = Array.from(val);
-      this.isEdit = false;
-      this.editingItem = false;
-    },
-  },
-  created() {},
-  mounted() {
-    this.items = Array.from(this.credentialDefinitions);
-  },
-  data: () => {
-    return {
-      items: [],
-      isEdit: false,
-      editingItem: null,
-      isBusy: false,
-    };
-  },
-  computed: {
-    isTailsConfigured() {
-      return this.$config.tailsServerConfigured;
-    },
-  },
-  methods: {
-    addItem() {
-      this.isEdit = true;
-      this.items.push({
-        schemaId: this.id,
-        tag: "",
-        supportRevocation: false,
-        isEdit: true,
-      });
-    },
+    methods: {
+      addItem() {
+        this.isEdit = true;
+        this.items.push({
+          schemaId: this.id,
+          tag: "",
+          supportRevocation: false,
+          isEdit: true,
+        });
+      },
 
-    deleteItem(index) {
-      let item = this.items[index];
-      if (item.id) {
+      deleteItem(index) {
+        let item = this.items[index];
+        if (item.id) {
+          issuerService
+            .deleteCredDef(item.id)
+            .then((result) => {
+              console.log(result);
+              this.items.splice(index, 1);
+              this.$emit("changed");
+            })
+            .catch((e) => {
+              EventBus.$emit("error", this.$axiosErrorMessage(e));
+            });
+        } else {
+          this.items.splice(index, 1);
+        }
+      },
+
+      saveItem(item) {
+        this.createNewItem(item);
+      },
+
+      createNewItem(item) {
+        this.isBusy = true;
+        const data = {
+          schemaId: this.schema.schemaId,
+          tag: item.tag,
+          supportRevocation: item.supportRevocation,
+        };
         issuerService
-          .deleteCredDef(item.id)
+          .createCredDef(data)
           .then((result) => {
-            console.log(result);
-            this.items.splice(index, 1);
-            this.$emit("changed");
+            this.isBusy = false;
+
+            if (result.status === 200) {
+              this.isEdit = false;
+              item.isEdit = false;
+              EventBus.$emit("success", "New credential definition added");
+              this.$emit("changed");
+            }
           })
           .catch((e) => {
+            this.isBusy = false;
             EventBus.$emit("error", this.$axiosErrorMessage(e));
           });
-      } else {
+      },
+
+      cancelSaveItem(index) {
+        this.isEdit = false;
+        this.editingItem = false;
         this.items.splice(index, 1);
       }
     },
-
-    saveItem(item) {
-      this.createNewItem(item);
-    },
-
-    createNewItem(item) {
-      this.isBusy = true;
-      const data = {
-        schemaId: this.schema.schemaId,
-        tag: item.tag,
-        supportRevocation: item.supportRevocation,
-      };
-      issuerService
-        .createCredDef(data)
-        .then((result) => {
-          this.isBusy = false;
-
-          if (result.status === 200) {
-            this.isEdit = false;
-            item.isEdit = false;
-            EventBus.$emit("success", "New credential definition added");
-            this.$emit("changed");
-          }
-        })
-        .catch((e) => {
-          this.isBusy = false;
-          EventBus.$emit("error", this.$axiosErrorMessage(e));
-        });
-    },
-  },
-};
+  };
 </script>

--- a/frontend/src/components/ManageSchema.vue
+++ b/frontend/src/components/ManageSchema.vue
@@ -71,6 +71,7 @@
               <credential-definitions
                 :schema="schema"
                 :credentialDefinitions="schema.credentialDefinitions"
+                :reset="resetChildForms"
                 @changed="onChanged"
               />
             </v-card>
@@ -80,6 +81,7 @@
               <trusted-issuers
                 :schema="schema"
                 :trustedIssuers="schema.trustedIssuer"
+                :reset="resetChildForms"
                 @changed="onChanged"
               />
             </v-card>
@@ -136,6 +138,7 @@ export default {
   data: () => {
     return {
       tab: null,
+      resetChildForms: false,
     };
   },
   computed: {
@@ -186,6 +189,7 @@ export default {
       this.$emit("changed");
     },
     closed() {
+      this.resetChildForms = !this.resetChildForms;
       this.$emit("closed");
     },
   },

--- a/frontend/src/components/PresentationRecord.vue
+++ b/frontend/src/components/PresentationRecord.vue
@@ -275,11 +275,12 @@ export default {
     toCredentialLabel(matchedCred) {
       if (matchedCred.credentialInfo) {
         const credInfo = matchedCred.credentialInfo;
+        const referentHash = credInfo.referent.split('-')[0];
         if (credInfo.credentialLabel) {
           return credInfo.credentialLabel;
         } else if (credInfo.schemaLabel) {
           if (credInfo.issuerLabel) {
-            return `${credInfo.schemaLabel} (${credInfo.issuerLabel})`;
+            return `${credInfo.schemaLabel} (${credInfo.issuerLabel}) - ${referentHash}`;
           } else {
             return credInfo.schemaLabel;
           }

--- a/frontend/src/components/TrustedIssuers.vue
+++ b/frontend/src/components/TrustedIssuers.vue
@@ -92,6 +92,10 @@ export default {
         return [];
       },
     },
+    reset: {
+      type: Boolean,
+      default: () => false,
+    },
   },
   watch: {
     schema() {
@@ -102,6 +106,14 @@ export default {
       this.items = Array.from(val);
       this.isEdit = false;
       this.editingTrustedIssuer = null;
+    },
+    reset(newVal, oldVal) {
+      // use this to reset the form, remove any outstanding items that are not saved.
+      if (newVal !== oldVal) {
+        this.items = Array.from(this.trustedIssuers);
+        this.isEdit = false;
+        this.editingTrustedIssuer = null;
+      }
     },
   },
   created() {},


### PR DESCRIPTION
Add some cleanup/reset to Cred Def and Trusted issuer components when closing Schema form.

The issue was strictly for our frontend. When we have a list of credential definitions to choose from (for issuing), if there was no Tag set, then the display is like `Schema Name (version) - `, and it should be `Schema Name (version) - Tag`.

I also did a check and returned a nicer error if you attempt to save the same tag (for a given schema) twice.

Did a little clean up on Credential Definitions and Trusted Issuers components, so when you close the Manage Schema form, those components will reset (currently would leave half-edited fields in place with whatever text hadn't been saved).

**NOTE:** I've put in a very temporary "hack" related to issue 611, just adding the referent id to the matching credential list labels so you can select from all the matches.  This does NOT actually fix the issue, I think it's a bigger refactoring/fix required.

Signed-off-by: Jason Sherman <jsherman@parcsystems.ca>

<a href="https://gitpod.io/#https://github.com/hyperledger-labs/business-partner-agent/pull/612"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

