### PR TITLE
Label updates (Issue Credential -> Credential Definition).

### DIFF
--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/model/BPASchema.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/model/BPASchema.java
@@ -27,7 +27,7 @@ import lombok.*;
 import javax.persistence.*;
 import java.time.Instant;
 import java.util.List;
-import java.util.Set;
+import java.util.SortedSet;
 import java.util.UUID;
 
 @Data
@@ -51,7 +51,7 @@ public class BPASchema {
 
     @TypeDef(type = DataType.JSON)
     @Singular
-    private Set<String> schemaAttributeNames;
+    private SortedSet<String> schemaAttributeNames;
 
     @Nullable
     private String defaultAttributeName;

--- a/frontend/src/components/Credential.vue
+++ b/frontend/src/components/Credential.vue
@@ -129,7 +129,6 @@ export default {
 
     filteredSchemaField() {
       let fields = this.schema.fields;
-      fields.sort((a,b) => a.label.localeCompare(b.label));
       if (!this.isReadOnly) {
         return fields;
       } else {

--- a/frontend/src/components/Credential.vue
+++ b/frontend/src/components/Credential.vue
@@ -129,6 +129,7 @@ export default {
 
     filteredSchemaField() {
       let fields = this.schema.fields;
+      fields.sort((a,b) => a.label.localeCompare(b.label));
       if (!this.isReadOnly) {
         return fields;
       } else {

--- a/frontend/src/components/IssueCredential.vue
+++ b/frontend/src/components/IssueCredential.vue
@@ -238,7 +238,6 @@ export default {
     credDefSelected() {
       this.credentialFields = {};
       this.credDef.fields.forEach((x) => (this.credentialFields[x.type] = ""));
-      this.credDef.fields.sort((a,b) => a.label.localeCompare(b.label));
       this.submitDisabled = true;
     },
     enableSubmit() {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -110,13 +110,31 @@
         "action" : {
           "title": "Issue Credential",
           "button": "Issue Credential",
-          "partnerLabel": "Select partner...",
-          "credentialLabel": "Select credential..."
+          "partnerLabel": "Select Partner",
+          "credDefLabel": "Select Credential Definition"
         },
         "table" : {
           "title": "Issued Credentials"
         }
       }
+    },
+    "wallet": {
+      "title": "Wallet",
+      "credentials": {
+        "title": "Verifiable Credentials"
+      },
+      "documents": {
+        "title": "Documents"
+      }
+    }
+  },
+  "component": {
+    "issueCredential": {
+      "title": "Issue Credential",
+      "partnerLabel": "Partner",
+      "credDefLabel": "Credential Definition",
+      "successMessage": "Credential issued",
+      "fieldRequired": "{fieldName} is required"
     }
   },
   "constants": {

--- a/frontend/src/views/Wallet.vue
+++ b/frontend/src/views/Wallet.vue
@@ -8,7 +8,7 @@
 <template>
   <v-container>
     <v-card class="my-4">
-      <v-card-title class="bg-light"> Documents </v-card-title>
+      <v-card-title class="bg-light">{{$t("view.wallet.documents.title")}}</v-card-title>
       <MyCredentialList
         v-bind:headers="docHeaders"
         type="document"
@@ -43,7 +43,7 @@
       </v-card-actions>
     </v-card>
     <v-card class="my-10">
-      <v-card-title class="bg-light">Verified Credentials</v-card-title>
+      <v-card-title class="bg-light">{{$t("view.wallet.credentials.title")}}</v-card-title>
       <MyCredentialList
         v-bind:headers="credHeaders"
         type="credential"
@@ -68,7 +68,7 @@ export default {
     MyCredentialList,
   },
   created() {
-    EventBus.$emit("title", "Wallet");
+    EventBus.$emit("title", this.$t("view.wallet.title"));
     this.$store.dispatch("loadDocuments");
     this.$store.dispatch("loadSchemas");
   },

--- a/frontend/src/views/issuer/CredentialManagement.vue
+++ b/frontend/src/views/issuer/CredentialManagement.vue
@@ -14,7 +14,7 @@
       <v-card-actions>
         <v-layout align-end justify-end>
           <v-autocomplete
-            label="Select partner"
+            :label="$t('view.issueCredentials.cards.action.partnerLabel')"
             v-model="partner"
             :items="partners"
             return-object
@@ -48,7 +48,7 @@
             </template>
           </v-autocomplete>
           <v-autocomplete
-            label="Select credential"
+            :label="$t('view.issueCredentials.cards.action.credDefLabel')"
             v-model="credDef"
             :items="credDefs"
             return-object


### PR DESCRIPTION
Add some sorting on the issue credential screen, allow issue credential without all fields entered.
Previously, ALL fields were required which means you need data for every field which may not be true.
Adding sort of schema attributes when we fetch the BPA Schema model, allows for consistent rendering of the attribute order (alphabetical)

Signed-off-by: Jason Sherman <jsherman@parcsystems.ca>

<a href="https://gitpod.io/#https://github.com/hyperledger-labs/business-partner-agent/pull/613"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

