### PR TITLE
formatting for nev header image with max dimensions

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -25,10 +25,15 @@
               <!-- <v-list-item-subtitle></v-list-item-subtitle> -->
             </v-list-item-content>
             <v-list-item-content v-if="!ux.navigation.avatar.agent.default">
-              <v-list-item-title
-                ><v-img :src="ux.navigation.avatar.agent.src"></v-img
+              <v-list-item-title>
+                <v-img
+                  contain
+                  max-height="100"
+                  max-width="228"
+                  :src="ux.navigation.avatar.agent.src"
+                ></v-img
               ></v-list-item-title>
-              <v-list-item-subtitle
+              <v-list-item-subtitle class="text-center"
                 >Business Partner Agent</v-list-item-subtitle
               >
             </v-list-item-content>
@@ -65,21 +70,19 @@
         <v-list-item link :to="{ name: 'Notifications' }">
           <v-list-item-action>
             <v-badge
-                overlap
-                bordered
-                :content="taskNotificationsCount"
-                :value="taskNotificationsCount"
-                color="red"
-                offset-x="10"
-                offset-y="10"
+              overlap
+              bordered
+              :content="taskNotificationsCount"
+              :value="taskNotificationsCount"
+              color="red"
+              offset-x="10"
+              offset-y="10"
             >
               <v-icon>$vuetify.icons.notifications</v-icon>
             </v-badge>
           </v-list-item-action>
           <v-list-item-content>
-            <v-list-item-title>{{
-              $t("nav.notifications")
-              }}</v-list-item-title>
+            <v-list-item-title>{{ $t("nav.notifications") }}</v-list-item-title>
           </v-list-item-content>
         </v-list-item>
         <v-list-item link :to="{ name: 'PublicProfile' }">
@@ -131,13 +134,13 @@
         <v-list-item link :to="{ name: 'Partners' }">
           <v-list-item-action>
             <v-badge
-                overlap
-                bordered
-                :content="partnerNotificationsCount"
-                :value="partnerNotificationsCount"
-                color="red"
-                offset-x="10"
-                offset-y="10"
+              overlap
+              bordered
+              :content="partnerNotificationsCount"
+              :value="partnerNotificationsCount"
+              color="red"
+              offset-x="10"
+              offset-y="10"
             >
               <v-icon>$vuetify.icons.partners</v-icon>
             </v-badge>
@@ -232,29 +235,29 @@
       <router-view
         v-if="!sessionDialog && !$store.getters.taaRequired"
       ></router-view>
-        <v-btn
-            color="primary"
-            fab
-            dark
-            bottom
-            right
-            fixed
-            @click="showChatWindow"
-            style="text-decoration: none;"
+      <v-btn
+        color="primary"
+        fab
+        dark
+        bottom
+        right
+        fixed
+        @click="showChatWindow"
+        style="text-decoration: none"
+      >
+        <v-badge
+          overlap
+          bordered
+          :content="messagesReceivedCount"
+          :value="messagesReceivedCount"
+          color="red"
+          offset-x="10"
+          offset-y="10"
         >
-          <v-badge
-              overlap
-              bordered
-              :content="messagesReceivedCount"
-              :value="messagesReceivedCount"
-              color="red"
-              offset-x="10"
-              offset-y="10"
-          >
-            <v-icon v-if="chatWindow">$vuetify.icons.close</v-icon>
-            <v-icon v-else>$vuetify.icons.chat</v-icon>
-          </v-badge>
-        </v-btn>
+          <v-icon v-if="chatWindow">$vuetify.icons.close</v-icon>
+          <v-icon v-else>$vuetify.icons.chat</v-icon>
+        </v-badge>
+      </v-btn>
     </v-main>
 
     <v-snackbar
@@ -295,8 +298,12 @@
       </v-card>
     </v-dialog>
 
-    <div class="chat-window" :class="{opened: chatWindow, closed: !chatWindow}" style="z-index: 100">
-     <BasicMessages ref="basicMessages" />
+    <div
+      class="chat-window"
+      :class="{ opened: chatWindow, closed: !chatWindow }"
+      style="z-index: 100"
+    >
+      <BasicMessages ref="basicMessages" />
     </div>
 
     <v-footer app>
@@ -508,7 +515,7 @@ export default {
       }
       // now, open or close it
       this.chatWindow = !this.chatWindow;
-    }
+    },
   },
 };
 </script>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -21,7 +21,9 @@
               <v-img src="@/assets/logo_default.svg"></v-img>
             </v-list-item-avatar>
             <v-list-item-content v-if="ux.navigation.avatar.agent.default">
-              <v-list-item-title>{{ getAgentName }}</v-list-item-title>
+              <v-list-item-title class="text-wrap">{{
+                getOrganizationName | getAgentName
+              }}</v-list-item-title>
               <!-- <v-list-item-subtitle></v-list-item-subtitle> -->
             </v-list-item-content>
             <v-list-item-content v-if="!ux.navigation.avatar.agent.default">
@@ -33,9 +35,9 @@
                   :src="ux.navigation.avatar.agent.src"
                 ></v-img
               ></v-list-item-title>
-              <v-list-item-subtitle
-                >{{ getOrganizationName ? getOrganizationName : getAgentName }}
-              </v-list-item-subtitle>
+              <v-list-item-subtitle class="text-wrap">{{
+                getOrganizationName | getAgentName
+              }}</v-list-item-subtitle>
             </v-list-item-content>
           </v-list-item>
           <v-list-item
@@ -478,6 +480,7 @@ export default {
     }
 
     this.$store.dispatch("validateTaa");
+    this.$store.dispatch("loadDocuments");
 
     // Global Error handling
     // Todo: Put in extra component

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -434,12 +434,8 @@ export default {
       return bpaName;
     },
     getOrganizationName() {
-      console.log("dispatch");
-      this.$store.dispatch("loadDocuments");
       let profile = this.$store.getters.getOrganizationalProfile;
       if (profile) {
-        console.log(profile.label);
-        console.log(profile["label"]);
         return profile["label"];
       }
       return "";

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -33,9 +33,9 @@
                   :src="ux.navigation.avatar.agent.src"
                 ></v-img
               ></v-list-item-title>
-              <v-list-item-subtitle class="text-center"
-                >Business Partner Agent</v-list-item-subtitle
-              >
+              <v-list-item-subtitle
+                >{{ getOrganizationName ? getOrganizationName : getAgentName }}
+              </v-list-item-subtitle>
             </v-list-item-content>
           </v-list-item>
           <v-list-item
@@ -44,7 +44,7 @@
             class="pl-3 mt-n2"
           >
             <v-list-item-avatar style="width: fit-content">
-              <v-icon>$vuetify.icons.user</v-icon>
+              <v-icon>$vuetify.icons.domain</v-icon>
             </v-list-item-avatar>
             <v-list-item-content>
               <!-- show current user name? -->
@@ -430,6 +430,17 @@ export default {
         bpaName = nameSettingValue;
       }
       return bpaName;
+    },
+    getOrganizationName() {
+      console.log("dispatch");
+      this.$store.dispatch("loadDocuments");
+      let profile = this.$store.getters.getOrganizationalProfile;
+      if (profile) {
+        console.log(profile.label);
+        console.log(profile["label"]);
+        return profile["label"];
+      }
+      return "";
     },
     getTitle() {
       if (this.ux.header.title.prefix) {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -48,8 +48,8 @@
             <v-list-item-avatar style="width: fit-content">
               <v-icon>$vuetify.icons.domain</v-icon>
             </v-list-item-avatar>
-            <v-list-item-content>
-              <!-- show current user name? -->
+            <v-list-item-content class="text-wrap"
+              >{{ getOrganizationName | getAgentName }}
             </v-list-item-content>
           </v-list-item>
         </router-link>

--- a/frontend/src/plugins/vuetify.js
+++ b/frontend/src/plugins/vuetify.js
@@ -12,6 +12,7 @@ import {
   mdiCog,
   mdiChevronLeft,
   mdiDelete,
+  mdiDomain,
   mdiContentCopy,
   mdiPlus,
   mdiPencil,
@@ -36,7 +37,7 @@ import {
   mdiBookRemove,
   mdiMagnify,
   mdiTicketConfirmationOutline,
-  mdiAttachment
+  mdiAttachment,
 } from "@mdi/js";
 
 Vue.use(Vuetify);
@@ -65,6 +66,7 @@ export default new Vuetify({
       up: "fas fa-chevron-up",
       down: "fas fa-chevron-down",
       delete: mdiDelete,
+      domain: mdiDomain,
       copy: mdiContentCopy,
       add: mdiPlus,
       pencil: mdiPencil,
@@ -91,7 +93,7 @@ export default new Vuetify({
       search: mdiMagnify,
       dashboardGo: "fas fa-arrow-alt-circle-right",
       invitation: mdiTicketConfirmationOutline,
-      attachment: mdiAttachment
+      attachment: mdiAttachment,
     },
   },
   theme: {


### PR DESCRIPTION
With custom navigation header image provided. 

![Screenshot_20210913_164016](https://user-images.githubusercontent.com/5376854/133170841-3b7ddb94-5602-4efe-b7ee-7b2be9fe2db1.png)

With default flag set. 

![Screenshot_20210913_164832](https://user-images.githubusercontent.com/5376854/133171464-b6123d32-256e-42e2-9b20-0a780ce54e10.png)

Some formatting/prettier automatic changes. 


<a href="https://gitpod.io/#https://github.com/hyperledger-labs/business-partner-agent/pull/615"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

