### PR TITLE
Handle valid invitation type (didcomm)

### DIFF
--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/InvitationParser.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/InvitationParser.java
@@ -50,6 +50,9 @@ public class InvitationParser {
 
     OkHttpClient httpClient = new OkHttpClient.Builder().followRedirects(false).build();
 
+    static List<String> CONNECTION_INVITATION_TYPES = List.of("did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/connections/1.0/invitation","https://didcomm.org/connections/1.0/invitation");
+    static List<String> OOB_INVITATION_TYPES = List.of("did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/out-of-band/1.0/invitation","https://didcomm.org/out-of-band/1.0/invitation");
+
     @Inject
     @Setter(AccessLevel.PACKAGE)
     ObjectMapper mapper;
@@ -121,7 +124,7 @@ public class InvitationParser {
                     invitation.setInvitation(o);
                     invitation.setParsed(true);
 
-                    if ("did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/connections/1.0/invitation".equals(o.get("@type"))) {
+                    if (CONNECTION_INVITATION_TYPES.contains(o.get("@type"))) {
                         // Invitation
                         try {
                             Gson gson = GsonConfig.defaultConfig();
@@ -133,8 +136,7 @@ public class InvitationParser {
                             log.error(msg);
                         }
 
-                    } else if ("did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/out-of-band/1.0/invitation"
-                            .equals(o.get("@type"))) {
+                    } else if (OOB_INVITATION_TYPES.contains(o.get("@type"))) {
                         invitation.setOob(true);
 
                         Gson gson = GsonConfig.defaultConfig();

--- a/backend/business-partner-agent/src/test/java/org/hyperledger/bpa/impl/InvitationParserTest.java
+++ b/backend/business-partner-agent/src/test/java/org/hyperledger/bpa/impl/InvitationParserTest.java
@@ -45,6 +45,32 @@ public class InvitationParserTest {
         Assertions.assertNotNull(invitation.getInvitation());
     }
 
+    @Test
+    void TestParseReceiveDidCommInvitation() {
+        InvitationParser p = new InvitationParser();
+        p.setMapper(new ObjectMapper());
+
+        InvitationParser.Invitation invitation = p.parseInvitation(this.didCommInvitation);
+        Assertions.assertFalse(invitation.isOob());
+        Assertions.assertTrue(invitation.isParsed());
+        Assertions.assertNotNull(invitation.getInvitation());
+    }
+
+    @Test
+    void TestParseReceiveOOBDidCommInvitation() {
+        InvitationParser p = new InvitationParser();
+        p.setMapper(new ObjectMapper());
+
+        InvitationParser.Invitation invitation = p.parseInvitation(didCommOob);
+        Assertions.assertTrue(invitation.isOob());
+        Assertions.assertTrue(invitation.isParsed());
+        Assertions.assertNotNull(invitation.getInvitation());
+    }
+
     private final String invitation = "ewogICAgIkB0eXBlIjogImRpZDpzb3Y6QnpDYnNOWWhNcmpIaXFaRFRVQVNIZztzcGVjL2Nvbm5lY3Rpb25zLzEuMC9pbnZpdGF0aW9uIiwKICAgICJAaWQiOiAiNGQ1OGJhZjktZDIwOS00MTE4LThkOTQtNGE0OTBlNGEwNGFhIiwKICAgICJzZXJ2aWNlRW5kcG9pbnQiOiAiaHR0cDovL2hvc3QuZG9ja2VyLmludGVybmFsOjgwMzAiLAogICAgInJlY2lwaWVudEtleXMiOiBbCiAgICAgICAgIjZCTlF1dFJIalNWNmJwQ0E2djVkRVB2NW12dWlRS2hyc256cEN4dUgzdXdqIgogICAgXSwKICAgICJsYWJlbCI6ICJCdXNpbmVzcyBQYXJ0bmVyIEFnZW50IDEiCn0=";
     private final String oob = "eyJAdHlwZSI6ICJkaWQ6c292OkJ6Q2JzTlloTXJqSGlxWkRUVUFTSGc7c3BlYy9vdXQtb2YtYmFuZC8xLjAvaW52aXRhdGlvbiIsICJAaWQiOiAiMmZhYmJhNzYtZTlhNy00Yzk4LTg2ZjMtMTFkNGE1MTYzYjQyIiwgImhhbmRzaGFrZV9wcm90b2NvbHMiOiBbImRpZDpzb3Y6QnpDYnNOWWhNcmpIaXFaRFRVQVNIZztzcGVjL2RpZGV4Y2hhbmdlLzEuMCJdLCAic2VydmljZXMiOiBbImRpZDpzb3Y6RXJhWUNESlVQc0NoYmt3N1MxdlY5NiJdLCAibGFiZWwiOiAiYm9iIn0=";
+
+    private final String didCommInvitation = "eyJAdHlwZSI6ICJodHRwczovL2RpZGNvbW0ub3JnL2Nvbm5lY3Rpb25zLzEuMC9pbnZpdGF0aW9uIiwgIkBpZCI6ICJkNGE5ZmY4YS1jNjlmLTRiMWQtODJlYi04NzQwYWRiMzE0MmEiLCAic2VydmljZUVuZHBvaW50IjogImh0dHBzOi8vaW52aXRlMS1icGEtYWNhcHktZGV2LmFwcHMuc2lsdmVyLmRldm9wcy5nb3YuYmMuY2EiLCAibGFiZWwiOiAiaW52aXRlMSIsICJyZWNpcGllbnRLZXlzIjogWyI5MnV2TTFFOG9RbXFUNGZLZkdtam5UTndiandqYUZXYVRpRmtMZXNvbnhSVCJdfQ==";
+    private final String didCommOob = "eyJAdHlwZSI6ICJodHRwczovL2RpZGNvbW0ub3JnL291dC1vZi1iYW5kLzEuMC9pbnZpdGF0aW9uIiwgIkBpZCI6ICI2ZmYzY2UzNy1kYjM1LTRjYTctYTNkOS03MWJmNGYxYzhkYzQiLCAibGFiZWwiOiAiaW52aXRlMSIsICJzZXJ2aWNlcyI6IFsiZGlkOnNvdjpXc3FWaW4xWjRZdnZiODdzU1E3QzJtIl0sICJoYW5kc2hha2VfcHJvdG9jb2xzIjogWyJodHRwczovL2RpZGNvbW0ub3JnL2RpZGV4Y2hhbmdlLzEuMCJdfQ==";
+
 }


### PR DESCRIPTION
`https://didcomm.org/connections/1.0/invitation` is a valid invitation type, so let's handle the current case and this value.
IBM had generated a connection invitation with the didcomm format and we couldn't connect, so we needed to update our invitation parser class.

We can generate invitations with the same `@type` by starting the agent with `--emit-new-didcomm-prefix` option.

fixes #620

Signed-off-by: Jason Sherman <jsherman@parcsystems.ca>

<a href="https://gitpod.io/#https://github.com/hyperledger-labs/business-partner-agent/pull/623"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

