### PR TITLE
Connection by Invitation Activity Log

### DIFF
--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/aries/ConnectionManager.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/aries/ConnectionManager.java
@@ -279,7 +279,15 @@ public class ConnectionManager {
 
     private void resolveAndSend(ConnectionRecord record, Partner p) {
         // only incoming connections in state request
-        if (ConnectionState.REQUEST.equals(record.getState())) {
+        if (ConnectionRecord.ConnectionProtocol.CONNECTION_V1.equals(record.getConnectionProtocol())) {
+            // handle Connection Invitations...
+            // if we generate and they accept, we do not get a COMPLETED or ACTIVE state, only get to RESPONSE
+            // if they generate and we accept, we may get to ACTIVE, but definitely get to RESPONSE
+            // so consider RESPONSE as we are connected, just add a completed task saying connection accepted.
+            if (ConnectionState.RESPONSE.equals(record.getState())) {
+                eventPublisher.publishEventAsync(PartnerRequestCompletedEvent.builder().partner(p).build());
+            }
+        } else if (ConnectionState.REQUEST.equals(record.getState())) {
             didResolver.lookupIncoming(p);
             if (record.isIncomingConnection()) {
                 eventPublisher.publishEventAsync(PartnerRequestReceivedEvent.builder().partner(p).build());


### PR DESCRIPTION
Was creating a task when connecting by connection invitation that couldn't be closed.
Was not creating an activity log when connection by oob invitation.

Now, we just create an activity log when the connection is "complete" in both the `c_i` and `oob` invitations.

Signed-off-by: Jason Sherman <jsherman@parcsystems.ca>

<a href="https://gitpod.io/#https://github.com/hyperledger-labs/business-partner-agent/pull/631"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

