### PR TITLE
Public Profile layout

### DIFF
--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/aries/ConnectionManager.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/aries/ConnectionManager.java
@@ -281,9 +281,12 @@ public class ConnectionManager {
         // only incoming connections in state request
         if (ConnectionRecord.ConnectionProtocol.CONNECTION_V1.equals(record.getConnectionProtocol())) {
             // handle Connection Invitations...
-            // if we generate and they accept, we do not get a COMPLETED or ACTIVE state, only get to RESPONSE
-            // if they generate and we accept, we may get to ACTIVE, but definitely get to RESPONSE
-            // so consider RESPONSE as we are connected, just add a completed task saying connection accepted.
+            // if we generate and they accept, we do not get a COMPLETED or ACTIVE state,
+            // only get to RESPONSE
+            // if they generate and we accept, we may get to ACTIVE, but definitely get to
+            // RESPONSE
+            // so consider RESPONSE as we are connected, just add a completed task saying
+            // connection accepted.
             if (ConnectionState.RESPONSE.equals(record.getState())) {
                 eventPublisher.publishEventAsync(PartnerRequestCompletedEvent.builder().partner(p).build());
             }

--- a/frontend/src/components/Profile.vue
+++ b/frontend/src/components/Profile.vue
@@ -2,62 +2,68 @@
  Copyright (c) 2020 - for information on the respective copyright owner
  see the NOTICE file and/or the repository at
  https://github.com/hyperledger-labs/organizational-agent
- 
+
  SPDX-License-Identifier: Apache-2.0
 -->
 
 <template>
   <div>
-    <OrganizationalProfile
-      v-if="profile"
-      v-bind:documentData="profile"
-      isReadOnly
-    ></OrganizationalProfile>
-    <v-container v-for="(item, index) in credentials" v-bind:key="item.id">
-      <v-row>
-        <v-col cols="4">
-          <v-row>
-            <span class="grey--text text--darken-2 font-weight-medium">
-              <span v-if="item.type === CredentialTypes.UNKNOWN.type">{{
+    <v-card class="my-4">
+      <v-card-title class="bg-light">{{ $t("component.profile.organizationalProfile.title") }}</v-card-title>
+      <OrganizationalProfile
+          v-if="profile"
+          v-bind:documentData="profile"
+          isReadOnly
+      ></OrganizationalProfile>
+      <v-card-actions>
+        <!-- this should be protected by roles -->
+        <v-layout align-end justify-end>
+          <v-bpa-button color="secondary" @click="editProfile">{{ $t("component.profile.organizationalProfile.edit") }}</v-bpa-button>
+        </v-layout>
+      </v-card-actions>
+    </v-card>
+    <v-card class="my-4" v-for="(item) in credentials" v-bind:key="item.id">
+      <v-card-title class="bg-light"><span v-if="item.type === CredentialTypes.UNKNOWN.type">{{
                 item.credentialDefinitionId | credentialTag
               }}</span>
-              <span v-else>{{ item.typeLabel }}</span>
-            </span>
-          </v-row>
-          <v-row
-            v-if="item.issuer && profile.id !== item.issuer"
-            class="text-caption"
-          >
-            verified by {{ item.issuer }}
-          </v-row>
-          <v-row v-if="item.credentialData && item.credentialData.validFrom">
-            <v-icon small class="pt-1 mr-2">{{ validFrom }}</v-icon>
-            <span class="text-caption">{{
-              item.credentialData.validFrom | moment("YYYY-MM-DD")
-            }}</span>
-          </v-row>
-          <v-row v-if="item.credentialData && item.credentialData.validUntil">
-            <v-icon small class="pt-1 mr-2">{{ validUntil }}</v-icon>
-            <span class="text-caption">{{
-              item.credentialData.validUntil | moment("YYYY-MM-DD")
-            }}</span>
-          </v-row>
-        </v-col>
-        <v-col>
-          <Credential
-            v-bind:document="item"
-            isReadOnly
-            showOnlyContent
-          ></Credential>
-        </v-col>
+        <span v-else>{{ item.typeLabel }}</span></v-card-title>
+      <v-container>
+        <v-row>
+          <v-col cols="4">
+            <v-row
+              v-if="(item.issuer && profile) && (profile.id !== item.issuer)"
+              class="text-caption mt-1 ml-1"
+            >
+              {{ $t("component.profile.credential.verifiedByLabel") }} {{ item.issuer }}
+            </v-row>
+            <v-row v-if="item.credentialData && item.credentialData.validFrom" class="mt-1 ml-1 pt-1">
+              <v-icon small class="mt-1 ml-1 mr-2">{{ validFrom }}</v-icon>
+              <span class="text-caption mt-1">{{
+                item.credentialData.validFrom | moment("YYYY-MM-DD")
+              }}</span>
+            </v-row>
+            <v-row v-if="item.credentialData && item.credentialData.validUntil" class="mt-1 ml-1 pt-1">
+              <v-icon small class="mt-1 ml-1 mr-2">{{ validUntil }}</v-icon>
+              <span class="text-caption mt-1">{{
+                item.credentialData.validUntil | moment("YYYY-MM-DD")
+              }}</span>
+            </v-row>
+          </v-col>
+          <v-col>
+            <Credential
+              v-bind:document="item"
+              isReadOnly
+              showOnlyContent
+            ></Credential>
+          </v-col>
       </v-row>
-      <v-divider v-if="index < credentials.length - 1" class="my-4"></v-divider>
-    </v-container>
+      </v-container>
+    </v-card>
     <v-card v-if="!profile && credentials.length === 0" height="100px" flat>
       <v-container fill-height fluid text-center>
         <v-row align="center" justify="center">
           <v-col>
-            <h4 class="grey--text">Partner does not share a public profile</h4>
+            <h4 class="grey--text">{{ $t("component.profile.noProfileMsg") }}</h4>
           </v-col>
         </v-row>
       </v-container>
@@ -69,14 +75,16 @@
 import { CredentialTypes } from "../constants";
 import OrganizationalProfile from "@/components/OrganizationalProfile";
 import Credential from "@/components/Credential";
-import { getPartnerProfile } from "@/utils/partnerUtils";
+import { getPartnerProfile, getPartnerProfileRoute } from "@/utils/partnerUtils";
 import { mdiCalendarCheck } from "@mdi/js";
 import { mdiCalendarRemove } from "@mdi/js";
+import VBpaButton from "@/components/BpaButton";
 
 export default {
   components: {
     OrganizationalProfile,
     Credential,
+    VBpaButton
   },
   props: {
     partner: Object,
@@ -126,6 +134,12 @@ export default {
       }
       return credential;
     },
+    editProfile() {
+      let route = getPartnerProfileRoute(this.partner);
+      if (route) {
+        this.$router.push(route);
+      }
+    }
   },
 };
 </script>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -235,6 +235,16 @@
         "credDefLabel": "Credential Definition",
         "attributesTitle": "Credential Content"
       }
+    },
+    "profile": {
+      "organizationalProfile": {
+        "title": "Organizational Profile",
+        "edit": "Edit"
+      },
+      "credential": {
+        "verifiedByLabel": "verified by"
+      },
+      "noProfileMsg": "Partner does not share a public profile"
     }
   },
   "constants": {

--- a/frontend/src/utils/partnerUtils.js
+++ b/frontend/src/utils/partnerUtils.js
@@ -24,6 +24,22 @@ export const getPartnerProfile = (partner) => {
   return null;
 };
 
+export const getPartnerProfileRoute = (partner) => {
+  if (partner && {}.hasOwnProperty.call(partner, "credential")) {
+    let partnerProfile = partner.credential.find((cred) => {
+      return cred.type === CredentialTypes.PROFILE.type;
+    });
+    if (partnerProfile) {
+      if ({}.hasOwnProperty.call(partnerProfile, "credentialData")) {
+        return {name: "Credential", params: {id: partnerProfile.id}};
+      } else if ({}.hasOwnProperty.call(partnerProfile, "documentData")) {
+        return {name: "Document", params: {id: partnerProfile.id}};
+      }
+    }
+  }
+  return null;
+};
+
 export const getPartnerState = (partner) => {
   if ({}.hasOwnProperty.call(partner, "state")) {
     if (partner.state === PartnerStates.REQUEST.value) {


### PR DESCRIPTION
Put Org Profile and Creds in cards.
Allow user to jump directly to edit Org. Profile (requested from UAT).
Users were getting lost when they clicked on Public Profile and then couldn't edit their Organization name, compromise by adding direct jump to that edit form.  The edit button should be protected by RBAC in the future.

Signed-off-by: Jason Sherman <jsherman@parcsystems.ca>

![Screen Shot 2021-09-24 at 3 52 27 PM](https://user-images.githubusercontent.com/39388115/134748518-7e5e1d82-a9ff-46c1-9c7e-e6057ceadcd3.png)


<a href="https://gitpod.io/#https://github.com/hyperledger-labs/business-partner-agent/pull/636"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

