### PR TITLE
Set Nav/Dashboard Icon colors

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -13,7 +13,7 @@
           <v-list-item
             v-if="ux.navigation.avatar.agent.enabled"
             two-line
-            class="pl-3 mt-n2"
+            class="pl-3 mt-n2 logo"
           >
             <v-list-item-avatar v-if="ux.navigation.avatar.agent.default">
               <v-img v-if="logo" :src="logo"></v-img>
@@ -39,7 +39,7 @@
           <v-list-item
             v-if="ux.navigation.avatar.user.enabled"
             two-line
-            class="pl-3 mt-n2"
+            class="pl-3 mt-n2 logo"
           >
             <v-list-item-avatar style="width: fit-content">
               <v-icon>$vuetify.icons.domain</v-icon>
@@ -471,6 +471,11 @@ export default {
       if (uiColor) {
         // if the user stored an override of the primary color, load it.
         this.$vuetify.theme.themes.light.primary = uiColor;
+      }
+      const uiColorIcons = localStorage.getItem("uiColorIcons");
+      if (uiColorIcons) {
+        // if the user stored an override of the icons color, load it.
+        this.$vuetify.theme.themes.light.icons = uiColorIcons;
       }
       // Load up an alternate favicon
       if (this.ux.favicon) {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -465,7 +465,9 @@ export default {
         this.$vuetify.theme.dark = this.ux.theme.dark
           ? this.ux.theme.dark
           : false;
-        Object.assign(this.$vuetify.theme.themes, this.ux.theme.themes);
+        if (this.ux.theme.themes.light) {
+          Object.assign(this.$vuetify.theme.themes.light, this.ux.theme.themes.light);
+        }
       }
       const uiColor = localStorage.getItem("uiColor");
       if (uiColor) {

--- a/frontend/src/assets/scss/style.scss
+++ b/frontend/src/assets/scss/style.scss
@@ -93,7 +93,7 @@ a {
     height: 180px;
     width: 180px;
     font-size: 180px !important;
-    color: black !important;
+    color: var(--v-icons-base) !important;
   }
 
   // applied when using an svg icon (material design)
@@ -101,7 +101,7 @@ a {
     font-size: 180px;
     height: 180px;
     width: 180px;
-    color: black;
+    color: var(--v-icons-base);
   }
 
   // font size need to account for 3 number characters (ex 100).
@@ -146,6 +146,15 @@ nav {
   a {
     &:hover {
       text-decoration: none;
+    }
+  }
+
+  .v-list-item:not(.logo) {
+    .v-icon.v-icon {
+      color: var(--v-icons-base) !important;
+    }
+    .v-icon__svg {
+      color: var(--v-icons-base);
     }
   }
 

--- a/frontend/src/plugins/vuetify.js
+++ b/frontend/src/plugins/vuetify.js
@@ -39,7 +39,7 @@ import {
   mdiTicketConfirmationOutline,
   mdiAlertCircle,
   mdiAlert,
-  mdiAttachment,
+  mdiAttachment
 } from "@mdi/js";
 
 Vue.use(Vuetify);
@@ -125,6 +125,7 @@ export default new Vuetify({
         font: "#313132",
         anchor: "#1A5A96",
         anchorHover: "#3B99FC",
+        icons: "#000000"
       },
     },
   },

--- a/frontend/src/views/settings/Settings.vue
+++ b/frontend/src/views/settings/Settings.vue
@@ -52,15 +52,37 @@
         </v-list-item-title>
         <v-list-item-subtitle align="end">
           <text-field-color-picker
-            v-if="isEditingColor"
-            @on-save="onPickColor"
-            @on-cancel="isEditingColor = false"
+              id="uiColor"
+              v-if="isEditingColor"
+              @on-save="onPickColor"
+              @on-cancel="isEditingColor = false"
           >
           </text-field-color-picker>
           <span v-else>{{ $vuetify.theme.themes.light.primary }}</span>
         </v-list-item-subtitle>
         <v-list-item-action v-show="!isEditingColor">
           <v-btn icon x-small @click="isEditingColor = !isEditingColor">
+            <v-icon dark>$vuetify.icons.pencil</v-icon>
+          </v-btn>
+        </v-list-item-action>
+      </v-list-item>
+      <v-list-item>
+        <v-list-item-title class="grey--text text--darken-2 font-weight-medium">
+          Icons Color
+        </v-list-item-title>
+        <v-list-item-subtitle align="end">
+          <text-field-color-picker
+              id="uiColorIcons"
+              :base-color="$vuetify.theme.themes.light.icons"
+              v-if="isEditingColorIcons"
+              @on-save="onPickColorIcons"
+              @on-cancel="isEditingColorIcons = false"
+          >
+          </text-field-color-picker>
+          <span v-else>{{ $vuetify.theme.themes.light.icons }}</span>
+        </v-list-item-subtitle>
+        <v-list-item-action v-show="!isEditingColorIcons">
+          <v-btn icon x-small @click="isEditingColorIcons = !isEditingColorIcons">
             <v-icon dark>$vuetify.icons.pencil</v-icon>
           </v-btn>
         </v-list-item-action>
@@ -130,6 +152,7 @@ export default {
         },
       ],
       isEditingColor: false,
+      isEditingColorIcons: false,
     };
   },
   computed: {
@@ -160,6 +183,11 @@ export default {
       this.$vuetify.theme.themes.light.primary = c;
       localStorage.setItem("uiColor", c);
       this.isEditingColor = false;
+    },
+    onPickColorIcons(c) {
+      this.$vuetify.theme.themes.light.icons = c;
+      localStorage.setItem("uiColorIcons", c);
+      this.isEditingColorIcons = false;
     },
     getStatus() {
       console.log("Getting status...");


### PR DESCRIPTION
Add a setting to Vuetify for icon colors, and allow user to set at runtime similar to the Frontend/Primary color.
Default is black (what it is currently).

Will add configuration to the chart.


Signed-off-by: Jason Sherman <jsherman@parcsystems.ca>

<a href="https://gitpod.io/#https://github.com/hyperledger-labs/business-partner-agent/pull/643"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

