### PR TITLE
Schema Attribute RegEx change.

### DIFF
--- a/frontend/src/components/CreateSchema.vue
+++ b/frontend/src/components/CreateSchema.vue
@@ -30,7 +30,7 @@
                 label="Schema Name"
                 placeholder="Published schema name (ex. my-schema)"
                 v-model="schemaName"
-                :rules="[rules.required, rules.schemaText]"
+                :rules="[rules.required, rules.schemaName]"
                 required
                 outlined
                 dense
@@ -72,7 +72,7 @@
                   <v-text-field
                     placeholder="Ex. companyName or company-name"
                     v-model="attr.text"
-                    :rules="[rules.required, rules.schemaText]"
+                    :rules="[rules.required, rules.schemaAttributeName]"
                     outlined
                     dense
                   ></v-text-field>
@@ -150,11 +150,14 @@ export default {
       rules: {
         required: (value) => !!value || "Can't be empty",
         version: (value) =>
-          (value && /^(\d+)\.(\d+)(?:\.\d+)?$/.test(value)) ||
+          textUtils.isValidSchemaVersion(value) ||
           "Must be follow common version numbering (ex. 1.2 or 1.2.3)",
-        schemaText: (value) =>
+        schemaName: (value) =>
+            textUtils.isValidSchemaName(value) ||
+            "Must be alphanumeric with optional '_' or '-'.",
+        schemaAttributeName: (value) =>
           textUtils.isValidSchemaAttributeName(value) ||
-          "Must be alphanumeric with optional '_' or '-'",
+          "Must be lowercase alpha with optional '_'.",
       },
     };
   },
@@ -162,9 +165,10 @@ export default {
     fieldsEmpty() {
       return (
         this.schemaLabel.length === 0 ||
-        this.schemaName.length === 0 ||
-        this.schemaVersion.length === 0 ||
-        this.schemaAttributes.length === 0
+        this.schemaName.length === 0 || !textUtils.isValidSchemaName(this.schemaName) ||
+        this.schemaVersion.length === 0 || !textUtils.isValidSchemaVersion(this.schemaVersion) ||
+        this.schemaAttributes.filter((x) => x.text.trim().length).length === 0 ||
+        this.schemaAttributes.filter((x) => x.text.trim().length).some(x => !textUtils.isValidSchemaAttributeName(x.text))
       );
     },
   },

--- a/frontend/src/utils/textUtils.js
+++ b/frontend/src/utils/textUtils.js
@@ -17,4 +17,8 @@ export const schemaAttributeLabel = (key) => {
   return key;
 };
 
-export const isValidSchemaAttributeName = (value) => (value && /^[a-zA-Z\d-_]+$/.test(value));
+export const isValidSchemaName = (value) => (value && /^[a-zA-Z\d-_]+$/.test(value));
+
+export const isValidSchemaAttributeName = (value) => (value && /^[a-z_]+$/.test(value));
+
+export const isValidSchemaVersion = (value) => (value && /^(\d+)\.(\d+)(?:\.\d+)?$/.test(value));


### PR DESCRIPTION
schemas with capital letters and/or mixed case cause errors on credential comparison/match

Signed-off-by: Jason Sherman <jsherman@parcsystems.ca>

<a href="https://gitpod.io/#https://github.com/hyperledger-labs/business-partner-agent/pull/657"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

