### PR TITLE
Bug: get Cred Ex for review was triggering state change

### DIFF
--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/IssuerCredentialManager.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/IssuerCredentialManager.java
@@ -300,8 +300,8 @@ public class IssuerCredentialManager extends BaseCredentialManager {
     }
 
     public CredEx getCredEx(@NonNull UUID id) {
-        BPACredentialExchange ex = this.getCredentialExchange(id);
-        return CredEx.from(ex, conv.toAPIObject(ex.getPartner()));
+        BPACredentialExchange credEx = credExRepo.findById(id).orElseThrow(EntityNotFoundException::new);
+        return CredEx.from(credEx, conv.toAPIObject(credEx.getPartner()));
     }
 
     public CredEx revokeCredentialExchange(@NonNull UUID id) {


### PR DESCRIPTION
When the issuer wants to review the credential exchange (what we issued and whether it was accepted/declined), we just need the data from the db. Was calling the full check to see if it is in db and wallet (important for holder), this was triggering a state change to problem once the credentials exchange is auto-removed from the wallet - so this little fix ensures we can read historical data stored in BPA db. However, the original call that compares db and wallet is important (particularly for the holder) as the conversation/exchange is ongoing. 

Not sure what is going on with my local docker, but it was NOT picking up the changes to acapy images, so my local dev was using a slightly older version and this wasn't an issue.  🤷 

Signed-off-by: Jason Sherman <jsherman@parcsystems.ca>

<a href="https://gitpod.io/#https://github.com/hyperledger-labs/business-partner-agent/pull/666"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

