### PR TITLE
Disable auto respond credential request

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,24 +33,24 @@ The Business Partner Agent is built on top of the Hyperledger Self-Sovereign Ide
 | Role/Feature     | Flow                                                                    | Protocol Version                  |
 |------------------|-------------------------------------------------------------------------|-----------------------------------|
 | Issuer           |                                                                         |                                   |
-|                  | auto: issue credential                                                  | v1, v2                            |
-|                  | manual: send credential offer to holder                                 | v1, v2                            |
-|                  | manual: receive credential proposal from holder                         | v1, v2                            |
-|                  | manual: decline credential proposal from holder and provide reason      | v1, v2                            |
+|                  | auto: issue credential                                                  | indy: v1, v2                      |
+|                  | manual: send credential offer to holder                                 | indy: v1, v2                      |
+|                  | manual: receive credential proposal from holder                         | indy: v1, v2                      |
+|                  | manual: decline credential proposal from holder and provide reason      | indy: v1, v2                      |
 |                  | revoke issued credential (requires tails server)                        | n/a                               |
 | Holder           |                                                                         |                                   |
-|                  | auto: receive credential                                                | v1, v2                            |
-|                  | manual: send credential proposal to issuer (based on document)          | v1, v2                            |
-|                  | manual: receive credential offer from issuer                            | v1, v2                            |
-|                  | manual: decline credential offer from issuer                            | v1, v2                            |
+|                  | auto: receive credential                                                | indy: v1, v2                      |
+|                  | manual: send credential proposal to issuer (based on document)          | indy: v1, v2                      |
+|                  | manual: receive credential offer from issuer                            | indy: v1, v2                      |
+|                  | manual: decline credential offer from issuer                            | indy: v1, v2                      |
 |                  | scheduled revocation check on all received credentials                  | n/a                               |
 | Prover           |                                                                         |                                   |
-|                  | auto: send presentation to verifier                                     | v1, v2                            |
-|                  | auto: answer presentation request                                       | v1, v2                            |
-|                  | manual: accept/decline presentation request and provide reason          | v1, v2                            |
+|                  | auto: send presentation to verifier                                     | indy: v1, v2                      |
+|                  | auto: answer presentation request                                       | indy: v1, v2                      |
+|                  | manual: accept/decline presentation request and provide reason          | indy: v1, v2                      |
 | Verifier         |                                                                         |                                   |
-|                  | auto: request presentation from prover based on proof template          | v1, v2                            |
-|                  | auto: receive and verify presentation from prover                       | v1, v2                            |
+|                  | auto: request presentation from prover based on proof template          | indy: v1, v2                      |
+|                  | auto: receive and verify presentation from prover                       | indy: v1, v2                      |
 | Connection       |                                                                         |                                   |
 |                  | connect by did:sov, did:web (if endpoint is aca-py)                     | did-exchange                      |
 |                  | receive invitation by URL                                               | connection-protocol, OOB          |

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/controller/PartnerController.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/controller/PartnerController.java
@@ -227,7 +227,7 @@ public class PartnerController {
         credM.sendCredentialRequest(
                 id,
                 UUID.fromString(credReq.getDocumentId()),
-                credReq.getVersion());
+                credReq.getExchangeVersion());
         return HttpResponse.ok();
     }
 

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/controller/api/partner/RequestCredentialRequest.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/controller/api/partner/RequestCredentialRequest.java
@@ -25,5 +25,5 @@ import org.hyperledger.aries.api.ExchangeVersion;
 @NoArgsConstructor
 public class RequestCredentialRequest {
     public String documentId;
-    public ExchangeVersion version;
+    public ExchangeVersion exchangeVersion;
 }

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/IssuerCredentialManager.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/IssuerCredentialManager.java
@@ -477,7 +477,7 @@ public class IssuerCredentialManager extends BaseCredentialManager {
                         bpaEx.getState(), bpaEx.getStateToTimestamp(),
                         ex.getRevocRegId(), ex.getRevocationId(), ex.getErrorMsg());
             }
-            if (ex.stateIsCredentialIssued() && ex.autoIssueEnabled()) {
+            if (ex.stateIsCredentialAcked() && ex.autoIssueEnabled()) {
                 ex.findAttributesInCredentialOfferDict().ifPresent(
                         attr -> {
                             credExRepo.updateCredential(bpaEx.getId(), Credential.builder().attrs(attr).build());
@@ -533,8 +533,8 @@ public class IssuerCredentialManager extends BaseCredentialManager {
     /**
      * In v2 (indy and w3c) a holder can decide to skip negotiation and directly
      * start the whole flow with a request. So we check if there is a preceding
-     * record if not decline with problem report TODO support v2 credential request
-     * without prior negotiation
+     * record if not decline with problem report
+     * TODO support v2 credential request without prior negotiation
      * 
      * @param ex {@link V20CredExRecord v2CredEx}
      */

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/IssuerCredentialManager.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/IssuerCredentialManager.java
@@ -533,8 +533,8 @@ public class IssuerCredentialManager extends BaseCredentialManager {
     /**
      * In v2 (indy and w3c) a holder can decide to skip negotiation and directly
      * start the whole flow with a request. So we check if there is a preceding
-     * record if not decline with problem report
-     * TODO support v2 credential request without prior negotiation
+     * record if not decline with problem report TODO support v2 credential request
+     * without prior negotiation
      * 
      * @param ex {@link V20CredExRecord v2CredEx}
      */

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/aries/AriesEventHandler.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/aries/AriesEventHandler.java
@@ -110,8 +110,8 @@ public class AriesEventHandler extends EventHandler {
         // holder events
         if (v1CredEx.roleIsHolder()) {
             synchronized (holderMgr) {
-                if (v1CredEx.stateIsCredentialReceived()) {
-                    holderMgr.handleV1CredentialExchangeReceived(v1CredEx);
+                if (v1CredEx.stateIsCredentialAcked()) {
+                    holderMgr.handleV1CredentialExchangeAcked(v1CredEx);
                 } else if (v1CredEx.stateIsOfferReceived()) {
                     holderMgr.handleOfferReceived(v1CredEx, ExchangeVersion.V1);
                 } else {

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/aries/AriesEventHandler.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/aries/AriesEventHandler.java
@@ -110,8 +110,8 @@ public class AriesEventHandler extends EventHandler {
         // holder events
         if (v1CredEx.roleIsHolder()) {
             synchronized (holderMgr) {
-                if (v1CredEx.stateIsCredentialAcked()) {
-                    holderMgr.handleV1CredentialExchangeAcked(v1CredEx);
+                if (v1CredEx.stateIsCredentialReceived()) {
+                    holderMgr.handleV1CredentialExchangeReceived(v1CredEx);
                 } else if (v1CredEx.stateIsOfferReceived()) {
                     holderMgr.handleOfferReceived(v1CredEx, ExchangeVersion.V1);
                 } else {
@@ -125,6 +125,8 @@ public class AriesEventHandler extends EventHandler {
             synchronized (issuerMgr) {
                 if (v1CredEx.stateIsProposalReceived()) {
                     issuerMgr.handleCredentialProposal(v1CredEx, ExchangeVersion.V1);
+                } else if (v1CredEx.stateIsRequestReceived()) {
+                    issuerMgr.handleV1CredentialRequest(v1CredEx);
                 } else {
                     issuerMgr.handleV1CredentialExchange(v1CredEx);
                 }
@@ -140,6 +142,8 @@ public class AriesEventHandler extends EventHandler {
                 if (v2CredEx.stateIsProposalReceived()) {
                     issuerMgr.handleCredentialProposal(v2CredEx.toV1CredentialExchangeFromProposal(),
                             ExchangeVersion.V2);
+                } else if (v2CredEx.stateIsRequestReceived()) {
+                    issuerMgr.handleV2CredentialRequest(v2CredEx);
                 } else {
                     issuerMgr.handleV2CredentialExchange(v2CredEx);
                 }
@@ -149,8 +153,8 @@ public class AriesEventHandler extends EventHandler {
                 if (v2CredEx.stateIsOfferReceived()) {
                     holderMgr.handleOfferReceived(
                             V2ToV1IndyCredentialConverter.INSTANCE().toV1Offer(v2CredEx), ExchangeVersion.V2);
-                } else if (v2CredEx.stateIsDone()) {
-                    holderMgr.handleV2CredentialDone(v2CredEx);
+                } else if (v2CredEx.stateIsCredentialReceived()) {
+                    holderMgr.handleV2CredentialReceived(v2CredEx);
                 } else {
                     holderMgr.handleStateChangesOnly(
                             v2CredEx.getCredExId(), v2CredEx.getState(),

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/aries/HolderCredentialManager.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/aries/HolderCredentialManager.java
@@ -367,7 +367,7 @@ public class HolderCredentialManager extends BaseCredentialManager {
     }
 
     // v1 credential, signed and stored in wallet
-    public void handleV1CredentialExchangeAcked(@NonNull V1CredentialExchange credEx) {
+    public void handleV1CredentialExchangeReceived(@NonNull V1CredentialExchange credEx) {
         String label = labelStrategy.apply(credEx.getCredential());
         holderCredExRepo.findByCredentialExchangeId(credEx.getCredentialExchangeId()).ifPresent(db -> {
             db
@@ -382,7 +382,7 @@ public class HolderCredentialManager extends BaseCredentialManager {
     }
 
     // v2 credential, signed and stored in wallet
-    public void handleV2CredentialDone(@NonNull V20CredExRecord credEx) {
+    public void handleV2CredentialReceived(@NonNull V20CredExRecord credEx) {
         holderCredExRepo.findByCredentialExchangeId(credEx.getCredExId()).ifPresent(
                 dbCred -> V2ToV1IndyCredentialConverter.INSTANCE().toV1Credential(credEx)
                         .ifPresent(c -> {

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/aries/HolderCredentialManager.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/aries/HolderCredentialManager.java
@@ -159,6 +159,7 @@ public class HolderCredentialManager extends BaseCredentialManager {
                 ac.issueCredentialV2SendProposal(v1CredentialProposalRequest).ifPresent(v2 -> dbCredEx
                         .threadId(v2.getThreadId())
                         .credentialExchangeId(v2.getCredExId())
+                        .exchangeVersion(ExchangeVersion.V2)
                         .credentialProposal(v2.toV1CredentialExchangeFromProposal().getCredentialProposalDict()
                                 .getCredentialProposal()));
             }
@@ -304,7 +305,8 @@ public class HolderCredentialManager extends BaseCredentialManager {
                 log.trace("Running revocation check for credential exchange: {}", cred.getReferent());
                 ac.credentialRevoked(Objects.requireNonNull(cred.getReferent())).ifPresent(isRevoked -> {
                     if (isRevoked.getRevoked() != null && isRevoked.getRevoked()) {
-                        holderCredExRepo.updateRevoked(cred.getId(), Boolean.TRUE);
+                        cred.pushStates(CredentialExchangeState.REVOKED, Instant.now());
+                        holderCredExRepo.updateRevoked(cred.getId(), Boolean.TRUE, cred.getStateToTimestamp());
                         log.debug("Credential with referent id: {} has been revoked", cred.getReferent());
                     }
                 });

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/aries/HolderCredentialManager.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/aries/HolderCredentialManager.java
@@ -367,7 +367,7 @@ public class HolderCredentialManager extends BaseCredentialManager {
     }
 
     // v1 credential, signed and stored in wallet
-    public void handleV1CredentialExchangeReceived(@NonNull V1CredentialExchange credEx) {
+    public void handleV1CredentialExchangeAcked(@NonNull V1CredentialExchange credEx) {
         String label = labelStrategy.apply(credEx.getCredential());
         holderCredExRepo.findByCredentialExchangeId(credEx.getCredentialExchangeId()).ifPresent(db -> {
             db

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/repository/HolderCredExRepository.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/repository/HolderCredExRepository.java
@@ -76,7 +76,8 @@ public interface HolderCredExRepository extends CrudRepository<BPACredentialExch
 
     void updateLabel(@Id UUID id, String label);
 
-    Number updateRevoked(@Id UUID id, Boolean revoked, StateChangeDecorator.StateToTimestamp<CredentialExchangeState> stateToTimestamp);
+    Number updateRevoked(@Id UUID id, Boolean revoked,
+            StateChangeDecorator.StateToTimestamp<CredentialExchangeState> stateToTimestamp);
 
     Number updateReferent(@Id UUID id, @Nullable String referent);
 

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/repository/HolderCredExRepository.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/repository/HolderCredExRepository.java
@@ -76,7 +76,7 @@ public interface HolderCredExRepository extends CrudRepository<BPACredentialExch
 
     void updateLabel(@Id UUID id, String label);
 
-    Number updateRevoked(@Id UUID id, Boolean revoked);
+    Number updateRevoked(@Id UUID id, Boolean revoked, StateChangeDecorator.StateToTimestamp<CredentialExchangeState> stateToTimestamp);
 
     Number updateReferent(@Id UUID id, @Nullable String referent);
 

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/util/CryptoUtil.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/util/CryptoUtil.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2020-2021 - for information on the respective copyright owner
+ * see the NOTICE file and/or the repository at
+ * https://github.com/hyperledger-labs/business-partner-agent
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hyperledger.bpa.util;
+
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.hyperledger.aries.config.GsonConfig;
+import org.springframework.security.crypto.codec.Hex;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+@Slf4j
+public class CryptoUtil {
+
+    public static boolean hashCompare(@NonNull Object base, @NonNull Object other) {
+        return hashCompare(GsonConfig.defaultConfig().toJson(base), GsonConfig.defaultConfig().toJson(other));
+    }
+
+    public static boolean hashCompare(@NonNull String base, @NonNull String other) {
+        String b = toSHA256Hex(base);
+        String o = toSHA256Hex(other);
+        if (b == null || o == null) {
+            return false;
+        }
+        return b.equals(o);
+    }
+
+    private static String toSHA256Hex(@NonNull String base) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA3-256");
+            final byte[] hashBytes = digest.digest(base.getBytes(StandardCharsets.UTF_8));
+            return String.valueOf(Hex.encode(hashBytes));
+        } catch (NoSuchAlgorithmException e) {
+            log.error("SHA3-256 not available");
+        }
+        return null;
+    }
+}

--- a/backend/business-partner-agent/src/main/resources/org/hyperledger/bpa/i18n/messages.properties
+++ b/backend/business-partner-agent/src/main/resources/org/hyperledger/bpa/i18n/messages.properties
@@ -54,6 +54,7 @@ api.proof.exchange.declined=User Declined Proof Request: No reason provided
 api.proof.exchange.wrong.state=PresentationExchangeState != 'request-received'
 api.proof.exchange.no.match=No matching credentials found for proof request: '{id}'
 api.proof.exchange.abandoned=Partner rejected proof exchange because it is not valid
+api.proof.exchange.default.name=Proof Request
 api.present.proof.wrong.state=PresentationExchangeRole!= 'prover' or PresentationExchangeState != 'request-received'
 
 api.proof.template.constraint.violation=Template can not be deleted because it is still in use.

--- a/backend/business-partner-agent/src/test/java/org/hyperledger/bpa/util/CryptoUtilTest.java
+++ b/backend/business-partner-agent/src/test/java/org/hyperledger/bpa/util/CryptoUtilTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020-2021 - for information on the respective copyright owner
+ * see the NOTICE file and/or the repository at
+ * https://github.com/hyperledger-labs/business-partner-agent
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hyperledger.bpa.util;
+
+import org.hyperledger.aries.api.credentials.CredentialAttributes;
+import org.hyperledger.aries.api.issue_credential_v1.V1CredentialExchange;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+public class CryptoUtilTest {
+
+    @Test
+    void testMatch() {
+        V1CredentialExchange.CredentialProposalDict.CredentialProposal p1 = create("test");
+        V1CredentialExchange.CredentialProposalDict.CredentialProposal p2 = create("test");
+        Assertions.assertTrue(CryptoUtil.hashCompare(p1, p2));
+    }
+
+    @Test
+    void testNoMatch() {
+        V1CredentialExchange.CredentialProposalDict.CredentialProposal p1 = create("test");
+        V1CredentialExchange.CredentialProposalDict.CredentialProposal p2 = create("other");
+        Assertions.assertFalse(CryptoUtil.hashCompare(p1, p2));
+    }
+
+    private V1CredentialExchange.CredentialProposalDict.CredentialProposal create(String value) {
+        return V1CredentialExchange.CredentialProposalDict.CredentialProposal
+                .builder()
+                .attributes(CredentialAttributes.from(Map.of("name", value)))
+                .build();
+    }
+}

--- a/frontend/src/components/CredExList.vue
+++ b/frontend/src/components/CredExList.vue
@@ -70,11 +70,7 @@
           >$vuetify.icons.revoke</v-icon
         >
         <v-icon
-          v-else-if="
-            isItemActive(item) &&
-            !item.revocable &&
-            item.role === exchangeRoles.HOLDER
-          "
+          v-else-if="isItemActive(item) && !item.revocable"
           color="green"
           :title="$t('component.credExList.table.holderNotRevocable')"
           >$vuetify.icons.check</v-icon

--- a/frontend/src/components/IssueCredential.vue
+++ b/frontend/src/components/IssueCredential.vue
@@ -134,7 +134,7 @@
               <v-list-item-title
                 class="grey--text text--darken-2 font-weight-medium"
               >
-                {{ $t("component.issueCredential.options.useV2") }}
+                {{ $t("button.useV2") }}
               </v-list-item-title>
             </v-list-item-content>
             <v-list-item-action>

--- a/frontend/src/components/PresentationExList.vue
+++ b/frontend/src/components/PresentationExList.vue
@@ -25,11 +25,7 @@
         ></new-message-icon>
       </template>
       <template v-slot:[`item.label`]="{ item }">
-        {{
-          item.proofRequest && item.proofRequest.name
-            ? item.proofRequest.name
-            : item.typeLabel
-        }}
+        {{ item.typeLabel }}
       </template>
 
       <template v-slot:[`item.role`]="{ item }">

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -54,7 +54,8 @@
     "no": "No",
     "close": "Close",
     "sendCounterOffer": "Send Counter Offer",
-    "revoke": "Revoke"
+    "revoke": "Revoke",
+    "useV2": "Use V2"
   },
   "view": {
     "notifications": {
@@ -245,8 +246,7 @@
       "successMessage": "Credential issued",
       "attributesTitle": "Credential Content",
       "options": {
-        "title": "Options",
-        "useV2": "Use V2 Protocol"
+        "title": "Options"
       },
       "expertLoad": {
         "title": "Load Credential Data",

--- a/frontend/src/views/RequestPresentation.vue
+++ b/frontend/src/views/RequestPresentation.vue
@@ -23,7 +23,7 @@
               <v-switch
                 v-if="expertMode"
                 v-model="useV2Exchange"
-                :label="$t('component.issueCredential.options.useV2')"
+                :label="$t('button.useV2')"
               ></v-switch>
               <v-bpa-button color="secondary" @click="cancel()">{{
                 $t("button.cancel")

--- a/frontend/src/views/RequestVerification.vue
+++ b/frontend/src/views/RequestVerification.vue
@@ -27,7 +27,12 @@
       </v-card-text>
 
       <v-card-actions>
-        <v-layout align-end justify-end>
+        <v-layout align-center align-end justify-end>
+          <v-switch
+            v-if="expertMode"
+            v-model="useV2Exchange"
+            :label="$t('button.useV2')"
+          ></v-switch>
           <v-bpa-button color="secondary" @click="cancel()"
             >Cancel</v-bpa-button
           >
@@ -75,7 +80,8 @@ import { EventBus } from "@/main";
 import PartnerList from "@/components/PartnerList";
 import VBpaButton from "@/components/BpaButton";
 import { getPartnerState } from "@/utils/partnerUtils";
-import {PartnerStates} from "@/constants";
+import { PartnerStates } from "@/constants";
+import { ExchangeVersion } from "@/constants";
 
 export default {
   name: "RequestVerification",
@@ -101,17 +107,23 @@ export default {
       isReady: false,
       attentionPartnerStateDialog: false,
       partner: {},
-      getPartnerState: getPartnerState
+      getPartnerState: getPartnerState,
+      useV2Exchange: false,
     };
   },
-  computed: {},
+  computed: {
+    expertMode() {
+      return this.$store.state.expertMode;
+    },
+  },
   methods: {
     checkRequest() {
       if (this.$refs.partnerList.selected.length === 1) {
         if (this.$refs.partnerList.selected[0].id) {
           this.partner = this.$refs.partnerList.selected[0];
           if (
-              this.getPartnerState(this.partner) === PartnerStates.ACTIVE_OR_RESPONSE
+            this.getPartnerState(this.partner) ===
+            PartnerStates.ACTIVE_OR_RESPONSE
           ) {
             this.submitRequest();
           } else {
@@ -130,6 +142,9 @@ export default {
           `${this.$apiBaseUrl}/partners/${this.partner.id}/credential-request`,
           {
             documentId: this.documentId,
+            exchangeVersion: this.useV2Exchange
+              ? ExchangeVersion.V2
+              : ExchangeVersion.V1,
           }
         )
         .then((res) => {
@@ -156,5 +171,4 @@ export default {
 .bg-light {
   background-color: #fafafa;
 }
-
 </style>

--- a/frontend/src/views/SendPresentation.vue
+++ b/frontend/src/views/SendPresentation.vue
@@ -30,7 +30,7 @@
           <v-switch
             v-if="expertMode"
             v-model="useV2Exchange"
-            :label="$t('component.issueCredential.options.useV2')"
+            :label="$t('button.useV2')"
           ></v-switch>
           <v-bpa-button color="secondary" @click="cancel()">{{
             $t("button.cancel")

--- a/scripts/acapy-static-args.yml
+++ b/scripts/acapy-static-args.yml
@@ -3,7 +3,7 @@ auto-accept-requests: false
 auto-respond-messages: false
 auto-respond-credential-proposal: false
 auto-respond-credential-offer: false
-auto-respond-credential-request: true
+auto-respond-credential-request: false
 auto-respond-presentation-proposal: true
 auto-respond-presentation-request: false
 auto-store-credential: true

--- a/scripts/scenarios/local-network/acapy-static-args.yml
+++ b/scripts/scenarios/local-network/acapy-static-args.yml
@@ -2,8 +2,8 @@ auto-accept-invites: false
 auto-accept-requests: false
 auto-respond-messages: false
 auto-respond-credential-proposal: false
-auto-respond-credential-offer: true
-auto-respond-credential-request: true
+auto-respond-credential-offer: false
+auto-respond-credential-request: false
 auto-respond-presentation-proposal: true
 auto-respond-presentation-request: false
 auto-store-credential: true


### PR DESCRIPTION
This PR is about fixing some remaining issues in the exchange states.

1. Store credential information on credential issued (only v2, not implemented in v1), as the acked event is only a courtesy and might not be implemented by all agents.
2. Disable auto respond credential request flag. This one is a bit tricky as in v1 indy a credential request event is always preceeded by an offer, so here we can always auto respond because the user has already accepted the offer. Whereas in v2 a holder can initiate the flow directly. This means running an agent with this auto flag enabled results in auto issuance, which could be a security issue when running none test bpa instances. So I changed the behaviour in the v2 handler that credential requests without a prior offer are denied. We can implement this flow later for v2, which is a nice shortcut feature.
3. Verry basic proof request name resolution. when receiving v1 proof proposals
4. Auto accepting crredential offer when offer == proposal, otherwise manual acceptance is required
5. Added v2 option to request verification flow



Signed-off-by: Philipp Etschel <philipp.etschel@ch.bosch.com>

<a href="https://gitpod.io/#https://github.com/hyperledger-labs/business-partner-agent/pull/668"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

