### PR TITLE
Display build number in settings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,27 @@ jobs:
         with:
           plugin_groups: '[ "com.spotify" ]' 
 
+      - name: Prepare docker tags for license image
+        id: preparetagslicense
+        uses: docker/metadata-action@v3
+        if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
+        with:
+          images: ghcr.io/hyperledger-labs/business-partner-agent-license
+          tags: |
+            type=ref,event=tag
+            type=edge,branch=main
+            type=sha
+
+      - name: Prepare docker tags for bpa image
+        id: preparetags
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/hyperledger-labs/business-partner-agent-new
+          tags: |
+            type=ref,event=tag
+            type=edge,branch=main
+            type=sha
+
       # Test Phase
 
       - name: Test with npm
@@ -74,7 +95,7 @@ jobs:
         run: cp -r ./frontend/dist ./backend/business-partner-agent/src/main/resources/public
 
       - name: Build backend
-        run: mvn -f backend/pom.xml clean package -DskipTests=true -Dspotbugs.skip=true -Dpmd.skip=true -Dlicense.skip=true
+        run: mvn -f backend/pom.xml clean package -Drevision=${{ fromJSON(steps.preparetags.outputs.json).labels['org.opencontainers.image.revision] }} -DskipTests=true -Dspotbugs.skip=true -Dpmd.skip=true -Dlicense.skip=true
 
       # Docker Phase (triggered only on main or tag)
 
@@ -89,15 +110,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner}}
           password: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Prepare docker tags license image
-        uses: Surgo/docker-smart-tag-action@v1      
-        if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
-        id: preparetagslicense
-        with:
-          docker_image: ghcr.io/hyperledger-labs/business-partner-agent-license
-          default_branch: ${{ github.event.repository.default_branch }}
-          tag_with_sha: true 
 
       - name: Build and push license container
         if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
@@ -106,16 +118,7 @@ jobs:
           context: .
           push: true
           file: Dockerfile.license
-          tags: ${{ steps.preparetagslicense.outputs.tag }}
-          
-      - name: Prepare docker images bpa
-        uses: Surgo/docker-smart-tag-action@v1
-        if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
-        id: preparetags
-        with:
-          docker_image: ghcr.io/hyperledger-labs/business-partner-agent-new
-          default_branch: ${{ github.event.repository.default_branch }}
-          tag_with_sha: true
+          tags: ${{ steps.preparetagslicense.outputs.tags }}
 
       - name: Build and push container
         if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
@@ -124,4 +127,4 @@ jobs:
           context: .
           push: true
           file: Dockerfile.run
-          tags: ${{ steps.preparetags.outputs.tag }}
+          tags: ${{ steps.preparetags.outputs.tags }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,7 @@ jobs:
           images: ghcr.io/hyperledger-labs/business-partner-agent-new
           tags: |
             type=ref,event=tag
+            type=ref,event=pr
             type=edge,branch=main
             type=sha
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
         run: cp -r ./frontend/dist ./backend/business-partner-agent/src/main/resources/public
 
       - name: Build backend
-        run: mvn -f backend/pom.xml clean package -Drevision=${{ fromJSON(steps.preparetags.outputs.json).labels['org.opencontainers.image.revision] }} -DskipTests=true -Dspotbugs.skip=true -Dpmd.skip=true -Dlicense.skip=true
+        run: mvn -f backend/pom.xml clean package -Drevision=${{ fromJSON(steps.preparetags.outputs.json).labels['org.opencontainers.image.revision'] }} -DskipTests=true -Dspotbugs.skip=true -Dpmd.skip=true -Dlicense.skip=true
 
       # Docker Phase (triggered only on main or tag)
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,9 +65,9 @@ jobs:
         with:
           images: ghcr.io/hyperledger-labs/business-partner-agent-new
           tags: |
-            type=ref,event=tag
-            type=sha
-            type=edge,branch=main
+            type=ref,event=tag,priority=900
+            type=sha,priority=800
+            type=edge,branch=main,priority=700
 
       # Test Phase
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,9 +66,8 @@ jobs:
           images: ghcr.io/hyperledger-labs/business-partner-agent-new
           tags: |
             type=ref,event=tag
-            type=ref,event=pr
-            type=edge,branch=main
             type=sha
+            type=edge,branch=main
 
       # Test Phase
 
@@ -96,7 +95,7 @@ jobs:
         run: cp -r ./frontend/dist ./backend/business-partner-agent/src/main/resources/public
 
       - name: Build backend
-        run: mvn -f backend/pom.xml clean package -Drevision=${{ fromJSON(steps.preparetags.outputs.json).labels['org.opencontainers.image.revision'] }} -DskipTests=true -Dspotbugs.skip=true -Dpmd.skip=true -Dlicense.skip=true
+        run: mvn -f backend/pom.xml clean package -Drevision=${{ fromJSON(steps.preparetags.outputs.json).labels['org.opencontainers.image.version'] }} -DskipTests=true -Dspotbugs.skip=true -Dpmd.skip=true -Dlicense.skip=true
 
       # Docker Phase (triggered only on main or tag)
 

--- a/backend/business-partner-agent-core/pom.xml
+++ b/backend/business-partner-agent-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.hyperledger.business-partner-agent</groupId>
         <artifactId>business-partner-agent-parent</artifactId>
-        <version>0.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>business-partner-agent-core</artifactId>

--- a/backend/business-partner-agent/pom.xml
+++ b/backend/business-partner-agent/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.hyperledger.business-partner-agent</groupId>
         <artifactId>business-partner-agent-parent</artifactId>
-        <version>0.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>business-partner-agent</artifactId>
@@ -224,6 +224,10 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven.compiler.plugin.version}</version>
                 <configuration>
@@ -265,14 +269,6 @@
                         </path>
                     </annotationProcessorPaths>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
             </plugin>
             <!-- mvn se.ayoy.maven-plugins:ayoy-license-verifier-maven-plugin:verify -->
             <plugin>

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/config/RuntimeConfig.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/config/RuntimeConfig.java
@@ -26,11 +26,14 @@ import jakarta.inject.Singleton;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.hyperledger.aries.AriesClient;
 import org.hyperledger.bpa.impl.StartupTasks;
 import org.hyperledger.bpa.impl.activity.DidResolver;
 
 import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Map;
 
 @Getter
@@ -87,16 +90,27 @@ public class RuntimeConfig implements ApplicationEventListener<StartupTasks.AcaP
     /** only set when running from .jar */
     String buildVersion;
 
+    @JsonIgnore
+    Instant startTime;
+
     public String getAgentName() {
         return DidResolver.splitDidFrom(agentName).getLabel();
+    }
+
+    public String getUptime() {
+        Duration up = Duration.between(startTime, Instant.now());
+        return DurationFormatUtils.formatDurationHMS(up.toMillis());
     }
 
     @Override
     public void onApplicationEvent(StartupTasks.AcaPyReady event) {
 
+        startTime = Instant.now();
         buildVersion = getClass().getPackage().getImplementationVersion();
         if (buildVersion != null) {
             log.info("BPA running with build version: {}", buildVersion);
+        } else {
+            buildVersion = "development";
         }
 
         try {

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/config/RuntimeConfig.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/config/RuntimeConfig.java
@@ -84,12 +84,17 @@ public class RuntimeConfig implements ApplicationEventListener<StartupTasks.AcaP
     @Value("${bpa.i18n.fallbackLocale}")
     String fallbackLocale;
 
+    String buildVersion;
+
     public String getAgentName() {
         return DidResolver.splitDidFrom(agentName).getLabel();
     }
 
     @Override
     public void onApplicationEvent(StartupTasks.AcaPyReady event) {
+        // only set when running from .jar
+        buildVersion = getClass().getPackage().getImplementationVersion();
+        log.info("BPA running with build version: {}", buildVersion);
         try {
             this.tailsServerConfigured = ac
                     .statusConfig()

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/config/RuntimeConfig.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/config/RuntimeConfig.java
@@ -84,6 +84,7 @@ public class RuntimeConfig implements ApplicationEventListener<StartupTasks.AcaP
     @Value("${bpa.i18n.fallbackLocale}")
     String fallbackLocale;
 
+    /** only set when running from .jar */
     String buildVersion;
 
     public String getAgentName() {
@@ -92,9 +93,12 @@ public class RuntimeConfig implements ApplicationEventListener<StartupTasks.AcaP
 
     @Override
     public void onApplicationEvent(StartupTasks.AcaPyReady event) {
-        // only set when running from .jar
+
         buildVersion = getClass().getPackage().getImplementationVersion();
-        log.info("BPA running with build version: {}", buildVersion);
+        if (buildVersion != null) {
+            log.info("BPA running with build version: {}", buildVersion);
+        }
+
         try {
             this.tailsServerConfigured = ac
                     .statusConfig()

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/prooftemplates/NonRevocationApplicator.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/prooftemplates/NonRevocationApplicator.java
@@ -25,8 +25,8 @@ import org.hyperledger.aries.api.present_proof.PresentProofRequest;
 import java.util.Objects;
 
 public class NonRevocationApplicator {
-    @Builder.Default
-    Boolean applyNonRevocation = false;
+
+    Boolean applyNonRevocation;
 
     PresentProofRequest.ProofRequest.ProofNonRevoked nonRevocation;
 

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/model/Partner.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/model/Partner.java
@@ -132,6 +132,7 @@ public class Partner extends StateChangeDecorator<Partner, ConnectionState> {
     @TypeDef(type = DataType.JSON)
     private Map<String, Object> supportedCredentials;
 
+    @Builder.Default
     @ManyToMany(cascade = { CascadeType.PERSIST, CascadeType.REFRESH })
     @JoinTable(name = "partner_tag")
     private Set<Tag> tags = new HashSet<>();

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/model/Tag.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/model/Tag.java
@@ -42,6 +42,7 @@ public class Tag {
 
     private String name;
 
+    @Builder.Default
     @ManyToMany(cascade = { CascadeType.PERSIST, CascadeType.REFRESH }, mappedBy = "tags")
     @JoinTable(name = "partner_tag")
     private Set<Partner> partners = new HashSet<>();

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.hyperledger.business-partner-agent</groupId>
     <artifactId>business-partner-agent-parent</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -44,6 +44,7 @@
     <properties>
         <!-- Settings -->
         <exec.mainClass />
+        <revision>0.1-SNAPSHOT</revision>
         <jdk.version>11</jdk.version>
         <m2e.apt.activation>maven_execution</m2e.apt.activation>
         <maven.compiler.target>${jdk.version}</maven.compiler.target>
@@ -54,6 +55,7 @@
         <!-- Dependency Versions -->
         <log4j2.version>2.14.1</log4j2.version>
         <lombok.version>1.18.22</lombok.version>
+        <lombok.maven.plugin.version>1.18.20.0</lombok.maven.plugin.version>
         <micronaut.version>3.1.3</micronaut.version>
         <micronaut.data.version>3.1.2</micronaut.data.version>
         <micronaut.openapi.version>3.2.0</micronaut.openapi.version>
@@ -325,6 +327,14 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>3.2.0</version>
+                    <configuration>
+                        <archive>
+                            <manifest>
+                                <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                                <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                            </manifest>
+                        </archive>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -425,12 +435,19 @@
                 <plugin>
                     <groupId>org.projectlombok</groupId>
                     <artifactId>lombok-maven-plugin</artifactId>
-                    <version>${lombok.version}</version>
+                    <version>${lombok.maven.plugin.version}</version>
                     <configuration>
                         <addOutputDirectory>false</addOutputDirectory>
                         <sourceDirectory>${project.basedir}/src/main/java</sourceDirectory>
                         <outputDirectory>${project.build.directory}/generated-sources/delombok</outputDirectory>
                     </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </dependency>
+                    </dependencies>
                     <executions>
                         <execution>
                             <phase>generate-sources</phase>
@@ -448,14 +465,6 @@
                         <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
                         <sourcepath>${project.build.directory}/generated-sources/delombok</sourcepath>
                     </configuration>
-                    <executions>
-                        <execution>
-                            <id>attach-javadocs</id>
-                            <goals>
-                                <goal>jar</goal>
-                            </goals>
-                        </execution>
-                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/frontend/src/components/UpdatePartner.vue
+++ b/frontend/src/components/UpdatePartner.vue
@@ -146,7 +146,7 @@ export default {
         .then((result) => {
           this.isBusy = false;
           if (result.status === 200) {
-            EventBus.$emit("success", "Parttner updated successfully");
+            EventBus.$emit("success", "Partner updated successfully");
             this.$emit("success");
           }
         })

--- a/frontend/src/views/settings/Settings.vue
+++ b/frontend/src/views/settings/Settings.vue
@@ -155,6 +155,10 @@ export default {
           value: "ledgerPrefix",
         },
         {
+          text: "Uptime HH:mm:ss.SSS",
+          value: "uptime",
+        },
+        {
           text: "Version",
           value: "buildVersion",
         },

--- a/frontend/src/views/settings/Settings.vue
+++ b/frontend/src/views/settings/Settings.vue
@@ -52,10 +52,10 @@
         </v-list-item-title>
         <v-list-item-subtitle align="end">
           <text-field-color-picker
-              id="uiColor"
-              v-if="isEditingColor"
-              @on-save="onPickColor"
-              @on-cancel="isEditingColor = false"
+            id="uiColor"
+            v-if="isEditingColor"
+            @on-save="onPickColor"
+            @on-cancel="isEditingColor = false"
           >
           </text-field-color-picker>
           <span v-else>{{ $vuetify.theme.themes.light.primary }}</span>
@@ -72,17 +72,21 @@
         </v-list-item-title>
         <v-list-item-subtitle align="end">
           <text-field-color-picker
-              id="uiColorIcons"
-              :base-color="$vuetify.theme.themes.light.icons"
-              v-if="isEditingColorIcons"
-              @on-save="onPickColorIcons"
-              @on-cancel="isEditingColorIcons = false"
+            id="uiColorIcons"
+            :base-color="$vuetify.theme.themes.light.icons"
+            v-if="isEditingColorIcons"
+            @on-save="onPickColorIcons"
+            @on-cancel="isEditingColorIcons = false"
           >
           </text-field-color-picker>
           <span v-else>{{ $vuetify.theme.themes.light.icons }}</span>
         </v-list-item-subtitle>
         <v-list-item-action v-show="!isEditingColorIcons">
-          <v-btn icon x-small @click="isEditingColorIcons = !isEditingColorIcons">
+          <v-btn
+            icon
+            x-small
+            @click="isEditingColorIcons = !isEditingColorIcons"
+          >
             <v-icon dark>$vuetify.icons.pencil</v-icon>
           </v-btn>
         </v-list-item-action>
@@ -149,6 +153,10 @@ export default {
         {
           text: "Ledger DID Prefix",
           value: "ledgerPrefix",
+        },
+        {
+          text: "Version",
+          value: "buildVersion",
         },
       ],
       isEditingColor: false,


### PR DESCRIPTION
- cleaned up delombok a bit, but it is not working -> duplicate class error, needs different paths, but as we are not shipping a javadoc jar I skipped this for now
- added option to set Maven .jar version from the build pipeline
- removed obsolete smart tag action from the build pipeline and replaced it with the metadata action
- version of the jar should be either sha or tag (in that order), but needs running on main to be sure, otherwise we need to fallback to the revision of the commit
- added build version und uptime to the UI settings section

Signed-off-by: Philipp Etschel <philipp.etschel@ch.bosch.com>

<a href="https://gitpod.io/#https://github.com/hyperledger-labs/business-partner-agent/pull/670"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

