### PR TITLE
Issuer option to select credential definition when receiving a proposal

### DIFF
--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/controller/api/issuer/CredentialOfferRequest.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/controller/api/issuer/CredentialOfferRequest.java
@@ -28,6 +28,7 @@ import java.util.Map;
 @NoArgsConstructor
 public class CredentialOfferRequest {
     private Boolean acceptProposal;
+    private String credDefId;
     private Map<String, String> attributes;
 
     public boolean acceptAll() {

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/repository/BPACredentialDefinitionRepository.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/repository/BPACredentialDefinitionRepository.java
@@ -25,6 +25,7 @@ import io.micronaut.data.model.query.builder.sql.Dialect;
 import io.micronaut.data.repository.CrudRepository;
 import org.hyperledger.bpa.model.BPACredentialDefinition;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -42,7 +43,7 @@ public interface BPACredentialDefinitionRepository extends CrudRepository<BPACre
     @Query("SELECT * FROM bpa_cred_def c " +
             "LEFT JOIN bpaschema s ON c.schema_id = s.id " +
             "WHERE s.schema_id = :schemaId")
-    Optional<BPACredentialDefinition> findBySchemaId(String schemaId);
+    List<BPACredentialDefinition> findBySchemaId(String schemaId);
 
     @NonNull
     Optional<BPACredentialDefinition> findByCredentialDefinitionId(@NonNull String credentialDefinitionId);

--- a/backend/business-partner-agent/src/main/resources/org/hyperledger/bpa/i18n/messages.properties
+++ b/backend/business-partner-agent/src/main/resources/org/hyperledger/bpa/i18n/messages.properties
@@ -32,6 +32,7 @@ api.issuer.credential.exchange.problem=Credential could not be issued, because t
 api.issuer.credential.exchange.declined=Issuer declined credential proposal: no reason provided
 api.issuer.credential.missing.revocation.info=Credential can not be revoked (missing revocation flag)
 api.issuer.credential.send.offer.wrong.state=Wrong exchange state expected: proposal received but was: {state}
+api.issuer.credential.send.offer.wrong.creddef=Provided credential definition id is not configured
 api.schema.credential.document.conversion.failure=Only documents that are based on a schema can be converted into a credential
 api.issuer.creddef.already.exists=Credential definition for schema '{id}' already exists with tag '{tag}'
 api.issuer.creddef.ledger.failure=Credential Definition not created; could not complete request with ledger

--- a/backend/business-partner-agent/src/test/java/org/hyperledger/bpa/repository/BPACredentialDefinitionRepositoryTest.java
+++ b/backend/business-partner-agent/src/test/java/org/hyperledger/bpa/repository/BPACredentialDefinitionRepositoryTest.java
@@ -24,6 +24,7 @@ import org.hyperledger.bpa.model.BPASchema;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -47,13 +48,20 @@ public class BPACredentialDefinitionRepositoryTest {
                 .build());
         credRepo.save(BPACredentialDefinition
                 .builder()
-                .credentialDefinitionId("my-cred-def")
+                .credentialDefinitionId("my-cred-def-01")
                 .schema(schema)
                 .tag("bob-issuer")
                 .revocationRegistrySize(200)
                 .build());
+        credRepo.save(BPACredentialDefinition
+                .builder()
+                .credentialDefinitionId("my-cred-def-02")
+                .schema(schema)
+                .tag("oscar-issuer")
+                .revocationRegistrySize(200)
+                .build());
 
-        Optional<BPACredentialDefinition> bySchemaId = credRepo.findBySchemaId(schemaId);
-        Assertions.assertTrue(bySchemaId.isPresent());
+        List<BPACredentialDefinition> bySchemaId = credRepo.findBySchemaId(schemaId);
+        Assertions.assertEquals(2, bySchemaId.size());
     }
 }

--- a/frontend/src/components/CredExList.vue
+++ b/frontend/src/components/CredExList.vue
@@ -123,7 +123,7 @@
             v-model="credDef"
             :items="credDefList"
             outlined
-            disabled
+            :disabled="!documentStateIsProposalReceived"
             dense
           ></v-select>
 
@@ -507,6 +507,7 @@ export default {
 
       const counterOffer = {
         acceptProposal,
+        credDefId: this.credDef.credentialDefinitionId,
         attributes: this.document.credentialData,
       };
 


### PR DESCRIPTION
Previously only the first matching credential definition was selected. Now the flow is:

- First match is selected, if no credential definition is found the proposal is rejected
- The issuer can change the preselection in the frontend

Signed-off-by: Philipp Etschel <philipp.etschel@ch.bosch.com>

<a href="https://gitpod.io/#https://github.com/hyperledger-labs/business-partner-agent/pull/675"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

