### PR TITLE
Update pom.xml

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -53,7 +53,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <skip.docker.build>true</skip.docker.build>
         <!-- Dependency Versions -->
-        <log4j2.version>2.14.1</log4j2.version>
+        <log4j2.version>2.15.0</log4j2.version>
         <lombok.version>1.18.22</lombok.version>
         <lombok.maven.plugin.version>1.18.20.0</lombok.maven.plugin.version>
         <micronaut.version>3.2.0</micronaut.version>


### PR DESCRIPTION
Added Code to prevent CVE-2021-44228 (Log4J JDNI issue)

All Log4J2 Versions < 2.15 are affected. Find infos here: https://blog.cloudflare.com/inside-the-log4j2-vulnerability-cve-2021-44228/


Signed-off-by: Martin Aulich martin.aulich@bosch.io

<a href="https://gitpod.io/#https://github.com/hyperledger-labs/business-partner-agent/pull/688"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

