### PR TITLE
added single quotes on file patterns in prettify command for frontend

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,7 @@
     "license-file-headers-update-year": "license-check-and-add remove -f license-header/config.json && npm run license-file-headers-add",
     "postinstall": "npm run license && npm run prettify",
     "prepare": "cd ../ && husky install ./frontend/.husky",
-    "prettify": "prettier --write **/*.{css,html,js,json,mjs,scss,ts,tsx,yml,md,vue}"
+    "prettify": "prettier --write '**/*.{css,html,js,json,mjs,scss,ts,tsx,yml,md,vue}'"
   },
   "dependencies": {
     "axios": "0.24.0",


### PR DESCRIPTION
On Mac, when I run
```sh
cd frontend/
npm install
```

I get errors like

```
[error] No files matching the pattern were found: "**/*.tsx".
[error] No files matching the pattern were found: "**/*.yml".
```

The quotations around the file patterns solve it.

<a href="https://gitpod.io/#https://github.com/hyperledger-labs/business-partner-agent/pull/716"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

