### PR TITLE
w3c interoperability fixes

### DIFF
--- a/backend/business-partner-agent/pom.xml
+++ b/backend/business-partner-agent/pom.xml
@@ -128,7 +128,7 @@
         <dependency>
             <groupId>network.idu.acapy</groupId>
             <artifactId>aries-client-python</artifactId>
-            <version>0.7.22</version>
+            <version>0.7.23-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.hyperledger.business-partner-agent</groupId>

--- a/backend/business-partner-agent/pom.xml
+++ b/backend/business-partner-agent/pom.xml
@@ -128,7 +128,7 @@
         <dependency>
             <groupId>network.idu.acapy</groupId>
             <artifactId>aries-client-python</artifactId>
-            <version>0.7.23-SNAPSHOT</version>
+            <version>0.7.23</version>
         </dependency>
         <dependency>
             <groupId>org.hyperledger.business-partner-agent</groupId>

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/client/DidDocClient.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/client/DidDocClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 - for information on the respective copyright owner
+ * Copyright (c) 2020-2022 - for information on the respective copyright owner
  * see the NOTICE file and/or the repository at
  * https://github.com/hyperledger-labs/business-partner-agent
  *

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/client/DidDocClient.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/client/DidDocClient.java
@@ -72,7 +72,7 @@ public class DidDocClient {
         } catch (IOException e) {
             throw new NetworkException(msg.getMessage("acapy.unavailable"), e);
         } catch (AriesException e) {
-            log.error("Could not resolve did document", e);
+            log.error("Could not resolve did document, code: {}, message: {}", e.getCode(), e.getMessage());
             throw new NetworkException(msg.getMessage("api.diddoc.resolution.error"), e);
         }
     }

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/controller/api/issuer/CredEx.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/controller/api/issuer/CredEx.java
@@ -87,6 +87,7 @@ public class CredEx {
                 || db.roleIsIssuer() && db.stateIsDeclined()) {
             credentialAttrs = db.proposalAttributesToMap();
         } else if (db.stateIsOfferReceived()
+                || db.stateIsRequestSent()
                 || db.roleIsHolder() && db.stateIsDeclined()) {
             credentialAttrs = db.offerAttributesToMap();
         } else {

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/controller/api/partner/CreatePartnerInvitationRequest.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/controller/api/partner/CreatePartnerInvitationRequest.java
@@ -30,8 +30,13 @@ public class CreatePartnerInvitationRequest {
     private List<Tag> tag;
     private Boolean trustPing;
     private Boolean useOutOfBand;
+    private Boolean usePublicDid;
 
     public boolean getUseOutOfBand() {
         return useOutOfBand != null && useOutOfBand;
+    }
+
+    public boolean getUsePublicDid() {
+        return usePublicDid != null && usePublicDid;
     }
 }

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/aries/AriesEventHandler.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/aries/AriesEventHandler.java
@@ -88,7 +88,7 @@ public class AriesEventHandler extends EventHandler {
             return;
         }
         synchronized (connection) {
-            if (connectionRecord.isConnectionInvitation()) {
+            if (connectionRecord.isInvitationResponse()) {
                 connection.handleInvitationEvent(connectionRecord);
             } else if (connectionRecord.isOutgoingConnection()) {
                 connection.handleOutgoingConnectionEvent(connectionRecord);

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/aries/connection/ConnectionManager.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/aries/connection/ConnectionManager.java
@@ -284,7 +284,7 @@ public class ConnectionManager {
                 });
     }
 
-    private String resolveDidFromRecord(@NonNull ConnectionRecord record) {
+    String resolveDidFromRecord(@NonNull ConnectionRecord record) {
         String did = null;
         if (record.protocolIsIdDidExchangeV1() && !record.isInvitationRequest()) {
             did = AriesStringUtil.qualifyDidIfNeeded(StringUtils.isNotEmpty(record.getTheirPublicDid())

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/aries/connection/ConnectionManager.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/aries/connection/ConnectionManager.java
@@ -294,6 +294,9 @@ public class ConnectionManager {
         if (StringUtils.isEmpty(did)) {
             did = AriesStringUtil.qualifyDidIfNeeded(record.getTheirDid(), "did:peer:");
         }
+        if (StringUtils.isEmpty(did)) {
+            did = UNKNOWN_DID;
+        }
         return did;
     }
 

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/aries/connection/ConnectionManager.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/aries/connection/ConnectionManager.java
@@ -116,7 +116,7 @@ public class ConnectionManager {
         InvitationRecord invitationRecord;
         try {
             if (req.getUseOutOfBand()) {
-                invitationRecord = createOOBInvitation(req.getAlias());
+                invitationRecord = createOOBInvitation(req.getAlias(), req.getUsePublicDid());
                 invMsgId = invitationRecord.getInviMsgId();
                 invitation
                         .invitationUrl(invitationRecord.getInvitationUrl())
@@ -412,11 +412,11 @@ public class ConnectionManager {
         return false;
     }
 
-    private InvitationRecord createOOBInvitation(@Nullable String alias) throws IOException {
+    private InvitationRecord createOOBInvitation(@Nullable String alias, boolean usePublicDid) throws IOException {
         return ac.outOfBandCreateInvitation(
                 InvitationCreateRequest.builder()
                         .alias(alias)
-                        .usePublicDid(Boolean.TRUE)
+                        .usePublicDid(usePublicDid)
                         .build(),
                 CreateInvitationFilter.builder()
                         .autoAccept(Boolean.TRUE)

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/aries/connection/InvitationParser.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/aries/connection/InvitationParser.java
@@ -142,7 +142,8 @@ public class InvitationParser {
                     invitation.setInvitation(o);
                     invitation.setParsed(true);
 
-                    if (CONNECTION_INVITATION_TYPES.contains((String) o.get("@type"))) {
+                    String type = (String) o.get("@type");
+                    if (CONNECTION_INVITATION_TYPES.contains(type)) {
                         // Invitation
                         try {
                             Gson gson = GsonConfig.defaultConfig();
@@ -154,7 +155,7 @@ public class InvitationParser {
                             log.error(msg);
                         }
 
-                    } else if (OOB_INVITATION_TYPES.contains((String) o.get("@type"))) {
+                    } else if (OOB_INVITATION_TYPES.contains(type)) {
                         invitation.setOob(true);
 
                         Gson gson = GsonConfig.defaultConfig();

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/util/AriesStringUtil.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/util/AriesStringUtil.java
@@ -31,9 +31,11 @@ public class AriesStringUtil {
 
     private static final Pattern DID_KEY_PATTERN = Pattern.compile("z[a-km-zA-HJ-NP-Z1-9]+");
     private static final String DID_KEY = "did:key:";
+    private static final String DID_INDY = "did:key:";
+    private static final String DID_SOV = "did:sov:";
 
     /**
-     * tests if the provided did is a did:key
+     * Tests if the provided did is a did:key
      * 
      * @param did
      * @return true if did is a did:key, false otherwise
@@ -45,6 +47,32 @@ public class AriesStringUtil {
             return m.matches();
         }
         return false;
+    }
+
+    /**
+     * Tests if the provided did is a did:indy
+     *
+     * @param did
+     * @return true if did is a did:indy, false otherwise
+     */
+    public static boolean isDidIndy(@Nullable String did) {
+        if (StringUtils.isNotEmpty(did) && did.startsWith(DID_INDY) || did.startsWith(DID_SOV)) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Checks if the provided did is fully qualified, if not it is prepended with the provided qualifier
+     * @param did qualified or unqualified did
+     * @param qualifier fallback qualifier if the provided did is unqualified
+     * @return qualified did
+     */
+    public static String qualifyDidIfNeeded(@Nullable String did, @NonNull String qualifier) {
+        if (did == null) {
+            return null;
+        }
+        return did.startsWith("did:") ? did : qualifier + did;
     }
 
     /**

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/util/AriesStringUtil.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/util/AriesStringUtil.java
@@ -56,7 +56,7 @@ public class AriesStringUtil {
      * @return true if did is a did:indy, false otherwise
      */
     public static boolean isDidIndy(@Nullable String did) {
-        if (StringUtils.isNotEmpty(did) && did.startsWith(DID_INDY) || did.startsWith(DID_SOV)) {
+        if (StringUtils.isNotEmpty(did) && (did.startsWith(DID_INDY) || did.startsWith(DID_SOV))) {
             return true;
         }
         return false;

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/util/AriesStringUtil.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/util/AriesStringUtil.java
@@ -63,8 +63,10 @@ public class AriesStringUtil {
     }
 
     /**
-     * Checks if the provided did is fully qualified, if not it is prepended with the provided qualifier
-     * @param did qualified or unqualified did
+     * Checks if the provided did is fully qualified, if not it is prepended with
+     * the provided qualifier
+     * 
+     * @param did       qualified or unqualified did
      * @param qualifier fallback qualifier if the provided did is unqualified
      * @return qualified did
      */

--- a/backend/business-partner-agent/src/test/java/org/hyperledger/bpa/impl/aries/connection/ConnectionManagerStatesTest.java
+++ b/backend/business-partner-agent/src/test/java/org/hyperledger/bpa/impl/aries/connection/ConnectionManagerStatesTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2020-2022 - for information on the respective copyright owner
+ * see the NOTICE file and/or the repository at
+ * https://github.com/hyperledger-labs/business-partner-agent
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hyperledger.bpa.impl.aries.connection;
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.hyperledger.aries.api.connection.ConnectionRecord;
+import org.hyperledger.aries.api.connection.ConnectionTheirRole;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@MicronautTest
+public class ConnectionManagerStatesTest {
+
+    @Inject
+    ConnectionManager m;
+
+    @Test
+    void testDidParsingByEventType() {
+        ConnectionRecord r = new ConnectionRecord();
+
+        r.setConnectionProtocol(ConnectionRecord.ConnectionProtocol.CONNECTION_V1)
+                .setTheirRole(ConnectionTheirRole.INVITEE)
+                .setTheirPublicDid(null)
+                .setTheirDid("1");
+        Assertions.assertEquals("did:peer:1", m.resolveDidFromRecord(r));
+
+        r.setConnectionProtocol(ConnectionRecord.ConnectionProtocol.CONNECTION_V1)
+                .setTheirRole(ConnectionTheirRole.INVITER)
+                .setInvitationMsgId("2")
+                .setTheirPublicDid(null)
+                .setTheirDid("1");
+        Assertions.assertEquals("did:peer:1", m.resolveDidFromRecord(r));
+
+        r.setConnectionProtocol(ConnectionRecord.ConnectionProtocol.DID_EXCHANGE_V1)
+                .setTheirRole(ConnectionTheirRole.REQUESTER)
+                .setInvitationMsgId("2")
+                .setTheirPublicDid(null)
+                .setTheirDid("1");
+        Assertions.assertEquals("did:peer:1", m.resolveDidFromRecord(r));
+
+        r.setConnectionProtocol(ConnectionRecord.ConnectionProtocol.DID_EXCHANGE_V1)
+                .setTheirRole(ConnectionTheirRole.RESPONDER)
+                .setInvitationMsgId("2")
+                .setTheirPublicDid("3")
+                .setTheirDid("1");
+        Assertions.assertEquals("did:sov:3", m.resolveDidFromRecord(r));
+
+        r.setConnectionProtocol(ConnectionRecord.ConnectionProtocol.DID_EXCHANGE_V1)
+                .setTheirRole(ConnectionTheirRole.REQUESTER)
+                .setInvitationMsgId(null)
+                .setTheirPublicDid(null)
+                .setTheirDid("1");
+        Assertions.assertEquals("did:sov:1", m.resolveDidFromRecord(r));
+
+        r.setConnectionProtocol(ConnectionRecord.ConnectionProtocol.DID_EXCHANGE_V1)
+                .setTheirRole(ConnectionTheirRole.RESPONDER)
+                .setInvitationMsgId(null)
+                .setTheirPublicDid("3")
+                .setTheirDid("1");
+        Assertions.assertEquals("did:sov:3", m.resolveDidFromRecord(r));
+    }
+}

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -53,7 +53,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <skip.docker.build>true</skip.docker.build>
         <!-- Dependency Versions -->
-        <log4j2.version>2.17.1</log4j2.version>
+        <log4j2.version>2.17.2</log4j2.version>
         <lombok.version>1.18.22</lombok.version>
         <lombok.maven.plugin.version>1.18.20.0</lombok.maven.plugin.version>
         <micronaut.version>3.3.3</micronaut.version>
@@ -63,7 +63,7 @@
         <mockito.version>4.3.1</mockito.version>
         <okhttp.version>4.9.3</okhttp.version>
         <org.mapstruct.version>1.4.2.Final</org.mapstruct.version>
-        <pmd.version>6.42.0</pmd.version>
+        <pmd.version>6.43.0</pmd.version>
         <spotbugs.version>4.5.3</spotbugs.version>
         <testcontainers.version>1.16.3</testcontainers.version>
         <!-- Plugin Versions -->
@@ -135,7 +135,7 @@
             <dependency>
                 <groupId>org.flywaydb</groupId>
                 <artifactId>flyway-core</artifactId>
-                <version>8.5.0</version>
+                <version>8.5.1</version>
             </dependency>
             <!-- Logging -->
             <dependency>

--- a/frontend/licenses/licenseInfos.json
+++ b/frontend/licenses/licenseInfos.json
@@ -131,15 +131,6 @@
     "license": "MIT",
     "licenseText": "The MIT License (MIT)\n\nCopyright © 2018 Ruben Taelman\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in\nall copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\nTHE SOFTWARE.\n"
   },
-  "lamejs": {
-    "ignore": false,
-    "name": "lamejs",
-    "version": "1.2.1",
-    "authors": "Alex Zhukov",
-    "url": "https://github.com/zhuker/lamejs",
-    "license": "LGPL-3.0",
-    "licenseText": "Can I use LAME in my commercial program?  \n\nYes, you can, under the restrictions of the LGPL.  The easiest\nway to do this is to:\n\n1. Link to LAME as separate jar (lame.min.js or lame.all.js)\n\n2. Fully acknowledge that you are using LAME, and give a link\n   to our web site, lame.sourceforge.net\n\n3. If you make modifications to LAME, you *must* release these\n   these modifications back to the LAME project, under the LGPL.\n"
-  },
   "linkify-it": {
     "ignore": false,
     "name": "linkify-it",
@@ -234,15 +225,6 @@
     "url": "https://github.com/markdown-it/uc.micro",
     "license": "MIT",
     "licenseText": "Copyright Mathias Bynens <https://mathiasbynens.be/>\n\nPermission is hereby granted, free of charge, to any person obtaining\na copy of this software and associated documentation files (the\n\"Software\"), to deal in the Software without restriction, including\nwithout limitation the rights to use, copy, modify, merge, publish,\ndistribute, sublicense, and/or sell copies of the Software, and to\npermit persons to whom the Software is furnished to do so, subject to\nthe following conditions:\n\nThe above copyright notice and this permission notice shall be\nincluded in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND,\nEXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\nMERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND\nNONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE\nLIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION\nOF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION\nWITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\n"
-  },
-  "use-strict": {
-    "ignore": false,
-    "name": "use-strict",
-    "version": "1.0.1",
-    "authors": "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)",
-    "url": "https://github.com/isaacs/use-strict",
-    "license": "ISC",
-    "licenseText": "The ISC License\n\nCopyright (c) Isaac Z. Schlueter and Contributors\n\nPermission to use, copy, modify, and/or distribute this software for any\npurpose with or without fee is hereby granted, provided that the above\ncopyright notice and this permission notice appear in all copies.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\" AND THE AUTHOR DISCLAIMS ALL WARRANTIES\nWITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF\nMERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR\nANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES\nWHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN\nACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR\nIN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.\n"
   },
   "v-click-outside": {
     "ignore": false,

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -305,6 +305,7 @@
       "createInvitation": "Einladung generieren (QR Code)",
       "invitationURL": "Einladung URL",
       "useOOB": "Out of Band verwenden",
+      "usePublicDid": "Öffentliche DID verwenden",
       "eventSuccessCreatePartnerInvite": "Einladung erfolgreich erstellt"
     },
     "proofTemplate": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -305,6 +305,7 @@
       "createInvitation": "Create Invitation",
       "invitationURL": "Send the QR code or the equivalent URL below as the connection invitation",
       "useOOB": "Out of Band",
+      "usePublicDid": "Use Public DID",
       "eventSuccessCreatePartnerInvite": "Partner Invitation created successfully"
     },
     "proofTemplate": {

--- a/frontend/src/views/partner/AddPartnerbyURL.vue
+++ b/frontend/src/views/partner/AddPartnerbyURL.vue
@@ -80,6 +80,21 @@
               </v-list-item-action>
             </v-list-item>
           </v-col>
+          <v-col cols="12" v-if="useOutOfBand">
+            <v-list-item>
+              <v-list-item-content>
+                <v-list-item-title
+                  class="grey--text text--darken-2 font-weight-medium"
+                  >{{
+                    $t("view.addPartnerbyURL.usePublicDid")
+                  }}</v-list-item-title
+                >
+              </v-list-item-content>
+              <v-list-item-action>
+                <v-switch v-model="usePublicDid"></v-switch>
+              </v-list-item-action>
+            </v-list-item>
+          </v-col>
           <v-col cols="12">
             <v-bpa-button color="primary" @click="createInvitation()">{{
               $t("view.addPartnerbyURL.createInvitation")
@@ -150,8 +165,9 @@ export default {
       // Disable trust ping for invitation to
       // mobile wallets by default.
       trustPing: false,
-      // Allow to use Out of Band format for invitation
+      // Allows using Out of Band format for the invitation
       useOutOfBand: false,
+      usePublicDid: true,
     };
   },
   computed: {
@@ -170,6 +186,7 @@ export default {
         }),
         trustPing: this.trustPing,
         useOutOfBand: this.useOutOfBand,
+        usePublicDid: this.useOutOfBand ? this.usePublicDid : undefined,
       };
       this.$axios
         .post(`${this.$apiBaseUrl}/invitations`, partnerToAdd)

--- a/scripts/acapy-static-args.yml
+++ b/scripts/acapy-static-args.yml
@@ -22,6 +22,8 @@ monitor-ping: true
 
 enable-undelivered-queue: true
 exch-use-unencrypted-tags: true
+emit-new-didcomm-prefix: true
+emit-new-didcomm-mime-type: true # wrong content-type otherwise
 preserve-exchange-records: false
 # currently, there is an issue with the tails file failing to upload if this is enabled
 # genesis-transactions-list: './genesis-transaction-list.yml'

--- a/scripts/acapy-static-args.yml
+++ b/scripts/acapy-static-args.yml
@@ -1,34 +1,51 @@
+# connection behaviour
+public-invites: true
 auto-accept-invites: false
 auto-accept-requests: false
+monitor-ping: true # enables the connection status in the ui
+auto-ping-connection: true # needed when using the connection protocol, otherwise the connection might not become active
+
+# auto message
 auto-respond-messages: false
+
+# auto credential exchange - issuer
 auto-respond-credential-proposal: false
-auto-respond-credential-offer: false
 auto-respond-credential-request: false
-auto-respond-presentation-proposal: true
+
+# auto credential exchange - holder
+auto-respond-credential-offer: false
+auto-store-credential: true # needed as there is no ui
+
+# auto presentation exchange
+auto-respond-presentation-proposal: true # needed as there is no ui
+auto-verify-presentation: true # needed as there is no ui
 auto-respond-presentation-request: false
 
-auto-store-credential: true
-auto-verify-presentation: true
+# credential and presentation exchanges
+preserve-exchange-records: false
 
-auto-ping-connection: true
-
-auto-provision: true
-
+# auto discover features protocol
 auto-disclose-features: true
 
+# wallet
+auto-provision: true
+wallet-type: 'indy'
+
+# revocation notifications (anoncreds only)
 notify-revocation: true
 monitor-revocation-notification: true
-monitor-ping: true
 
+# interoperability with other w3c wallets
+emit-new-didcomm-prefix: true
+emit-new-didcomm-mime-type: true # if true not backwards compatible with aca-py < 0.7.3
+
+# general aca-py config
 enable-undelivered-queue: true
 exch-use-unencrypted-tags: true
-emit-new-didcomm-prefix: true
-emit-new-didcomm-mime-type: true # wrong content-type otherwise
-preserve-exchange-records: false
-# currently, there is an issue with the tails file failing to upload if this is enabled
-# genesis-transactions-list: './genesis-transaction-list.yml'
-public-invites: true
 plugin: 'aries_cloudagent.messaging.jsonld'
 outbound-transport: http
-wallet-type: 'indy'
 log-level: info
+
+# multi ledger support
+# currently, there is an issue with the tails file failing to upload if this is enabled
+# genesis-transactions-list: './genesis-transaction-list.yml'


### PR DESCRIPTION
Testing connection and credential protocols against aries-framework-go.

**Fixes:**

- added option to create oob invitations with did:key
- prefixing peer did's with did:peer
- added aca-py's config flags that switch the didcomm mime-type as the wire format is not supported by the go-agent

**Tested:**
- Receive/create oob invitations with did:key works both ways bpa <-> framework-go
- Receive/create did-exchange invitation - is not working with aca-py as only did:indy is supported
- Issue/receive w3c credentials

**Go Agent Config in IDE**

Start flags:

```
start --api-host localhost:8081 \
     --database-type mem \
     --inbound-host http@<host-ip>:8082 \
     --inbound-host-external http@http://<host-ip>:8082
     --webhook-url http://<host-ip>:8080/log
     --log-level DEBUG 
     --agent-default-label MyGoAgent
```
Compiler flags:

```
-tags ACAPyInterop
```
Environment:
```
ARIESD_AUTO_ACCEPT=true
```

**Curl against go-agent**

Create did-exchange invitation
```
 curl  -X 'POST' \
  'http://localhost:8081/connections/create-invitation' \
  -H 'accept: application/json' \
  -d ''
```

Create oob invitation:
```
curl -X 'POST' \
  'http://localhost:8081/outofband/create-invitation' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{"label": "Go Agent"}'
```

Receive oob invitation:
```
curl -X POST "http://localhost:8081/outofband/accept-invitation" -H  "content-type: application/json" -d "{\"invitation\":{\"@id\":\"5fa6dc8e-63ed-4af8-ae32-2533c109ea47\",\"@type\":\"https://didcomm.org/out-of-band/1.0/invitation\",\"services\":[{\"id\":\"#inline\",\"type\":\"did-communication\",\"recipientKeys\":[\"did:key:z6MkjHKsXMwNbn1xjG3ge2WWT1Gq7FLeCo2sgRqW5pVgjqdn\"],\"serviceEndpoint\":\"http://<host-ip>:8888\"}],\"handshake_protocols\":[\"https://didcomm.org/didexchange/1.0\"]},\"my_label\": \"aca-py\"}"
```

Get connections
```
curl -X GET "http://localhost:8081/connections" -H  "accept: application/json"
```

Test if connecting to the transport works
```
curl -v -X 'POST' -H 'Content-Type: application/didcomm-envelope-enc'  http://:<host-ip>:8082
```

Signed-off-by: Philipp Etschel <philipp.etschel@ch.bosch.com>

<a href="https://gitpod.io/#https://github.com/hyperledger-labs/business-partner-agent/pull/718"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

