### PR TITLE
add --legacy-peer-deps flag to all pipelines

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,9 +28,9 @@ jobs:
       - name: Setup node and install deps
         uses: actions/setup-node@v2
         with:
-          node-version: '16.15.0'
-          check-latest: false
-      - run: npm --prefix frontend ci --no-optional
+          node-version: '16'
+          check-latest: true
+      - run: npm --prefix frontend ci --no-optional --legacy-peer-deps
 
       - name: Setup Java
         uses: actions/setup-java@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           node-version: '16'
           check-latest: true
-      - run: npm --prefix frontend ci --no-optional --legacy-peer-deps
+      - run: npm --prefix frontend ci --legacy-peer-deps
 
       - name: Setup Java
         uses: actions/setup-java@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # Dockerfile that builds frontend and backend, mainly used by the docker-compose files
 
 # Vue Build Container
-FROM node:16-buster-slim as VUE
+FROM node:16-buster as VUE
 WORKDIR /frontend
 COPY frontend .
-RUN npm ci --no-optional --legacy-peer-deps && npm run build
+RUN npm ci --legacy-peer-deps && npm run build
 
 # Micronaut build
 FROM maven:3-eclipse-temurin-17 as MAVEN

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # Dockerfile that builds frontend and backend, mainly used by the docker-compose files
 
 # Vue Build Container
-FROM node:16-alpine3.13 as VUE
+FROM node:16-buster-slim as VUE
 WORKDIR /frontend
 COPY frontend .
-RUN npm install && npm run build
+RUN npm ci --no-optional --legacy-peer-deps && npm run build
 
 # Micronaut build
 FROM maven:3-eclipse-temurin-17 as MAVEN

--- a/backend/business-partner-agent/pom.xml
+++ b/backend/business-partner-agent/pom.xml
@@ -428,7 +428,7 @@
                                     <goal>npm</goal>
                                 </goals>
                                 <configuration>
-                                    <arguments>ci --no-optional --legacy-peer-deps</arguments>
+                                    <arguments>ci --legacy-peer-deps</arguments>
                                 </configuration>
                             </execution>
                             <execution>

--- a/backend/business-partner-agent/pom.xml
+++ b/backend/business-partner-agent/pom.xml
@@ -417,8 +417,8 @@
                                 </goals>
                                 <configuration>
                                     <!-- See https://nodejs.org/en/download/ -->
-                                    <nodeVersion>v16.15.0</nodeVersion>
-                                    <npmVersion>8.5.5</npmVersion>
+                                    <nodeVersion>v16.15.1</nodeVersion>
+                                    <npmVersion>8.11.0</npmVersion>
                                 </configuration>
                             </execution>
                             <execution>
@@ -428,7 +428,7 @@
                                     <goal>npm</goal>
                                 </goals>
                                 <configuration>
-                                    <arguments>ci --no-optional</arguments>
+                                    <arguments>ci --no-optional --legacy-peer-deps</arguments>
                                 </configuration>
                             </execution>
                             <execution>

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -4,4 +4,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 save-exact=true
-optional=false
+save-prefix=
+omit[]=optional
+legacy-peer-deps=true

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -35675,8 +35675,7 @@
       "version": "4.5.15",
       "resolved": "https://registry.npmjs.org/@vue/cli-plugin-vuex/-/cli-plugin-vuex-4.5.15.tgz",
       "integrity": "sha512-fqap+4HN+w+InDxlA3hZTOGE0tzBTgXhKLoDydhywqgmhQ1D9JA6Feh94ze6tG8DsWX58/ujYUqA8jAz17FJtg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@vue/cli-service": {
       "version": "4.5.15",
@@ -35924,8 +35923,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@vue/preload-webpack-plugin/-/preload-webpack-plugin-1.1.2.tgz",
       "integrity": "sha512-LIZMuJk38pk9U9Ur4YzHjlIyMuxPlACdBIHH9/nGYVTsaGKOSnSuELiE8vS9wa+dJpIYspYUOqk+L1Q4pgHQHQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@vue/test-utils": {
       "version": "1.3.0",
@@ -36187,8 +36185,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -36237,15 +36234,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -36598,8 +36593,7 @@
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
       "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "babel-jest": {
       "version": "24.9.0",
@@ -43157,8 +43151,7 @@
           "version": "7.5.7",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
           "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -43586,8 +43579,7 @@
           "version": "7.5.7",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
           "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -43737,8 +43729,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "24.9.0",
@@ -44610,8 +44601,7 @@
     "linkifyjs": {
       "version": "2.1.9",
       "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-2.1.9.tgz",
-      "integrity": "sha512-74ivurkK6WHvHFozVaGtQWV38FzBwSTGNmJolEgFp7QgR2bl6ArUWlvT4GcHKbPe1z3nWYi+VUdDZk16zDOVug==",
-      "requires": {}
+      "integrity": "sha512-74ivurkK6WHvHFozVaGtQWV38FzBwSTGNmJolEgFp7QgR2bl6ArUWlvT4GcHKbPe1z3nWYi+VUdDZk16zDOVug=="
     },
     "lint-staged": {
       "version": "12.1.7",
@@ -48323,8 +48313,7 @@
     "qrcode.vue": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/qrcode.vue/-/qrcode.vue-1.7.0.tgz",
-      "integrity": "sha512-R7t6Y3fDDtcU7L4rtqwGUDP9xD64gJhIwpfjhRCTKmBoYF6SS49PIJHRJ048cse6OI7iwTwgyy2C46N9Ygoc6g==",
-      "requires": {}
+      "integrity": "sha512-R7t6Y3fDDtcU7L4rtqwGUDP9xD64gJhIwpfjhRCTKmBoYF6SS49PIJHRJ048cse6OI7iwTwgyy2C46N9Ygoc6g=="
     },
     "qs": {
       "version": "6.5.3",
@@ -59567,8 +59556,7 @@
     "vuetify": {
       "version": "2.6.6",
       "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.6.6.tgz",
-      "integrity": "sha512-H4KtxDFmDN8QiTRiGfBySyjMhVaHAJTKB0llGGKZT5jKxtnx9gvEtMWXKtVuRP0NJJP0H6xBPJHNOH7nT18qiQ==",
-      "requires": {}
+      "integrity": "sha512-H4KtxDFmDN8QiTRiGfBySyjMhVaHAJTKB0llGGKZT5jKxtnx9gvEtMWXKtVuRP0NJJP0H6xBPJHNOH7nT18qiQ=="
     },
     "vuetify-loader": {
       "version": "1.7.3",
@@ -59618,8 +59606,7 @@
     "vuex": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.6.2.tgz",
-      "integrity": "sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==",
-      "requires": {}
+      "integrity": "sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw=="
     },
     "w3c-hr-time": {
       "version": "1.0.2",


### PR DESCRIPTION
Related to: https://github.com/hyperledger-labs/business-partner-agent/issues/759
- same build params everywhere
- replaced version pinning with legacy param
- fixed omit optional dependencies
- only if developers change dependencies npm install should be used