### PR TITLE
load tags into partner within PartnerRepository

### DIFF
--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/persistence/repository/PartnerRepository.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/persistence/repository/PartnerRepository.java
@@ -51,15 +51,19 @@ public interface PartnerRepository extends CrudRepository<Partner, UUID> {
     @Join(value = "tags", type = Join.Type.LEFT_FETCH)
     Iterable<Partner> findAll();
 
+    @Join(value = "tags", type = Join.Type.LEFT_FETCH)
     Optional<Partner> findByConnectionId(String connectionId);
 
+    @Join(value = "tags", type = Join.Type.LEFT_FETCH)
     Optional<Partner> findByConnectionIdOrInvitationMsgId(@Nullable String connectionId,
             @Nullable String invitationMsgId);
 
+    @Join(value = "tags", type = Join.Type.LEFT_FETCH)
     Optional<Partner> findByDid(String did);
 
     List<Partner> findByDidIn(List<String> did);
 
+    @Join(value = "tags", type = Join.Type.LEFT_FETCH)
     Optional<Partner> findByInvitationMsgId(String invitationMsgId);
 
     @Query("SELECT distinct partner.* FROM partner,jsonb_to_recordset(partner.supported_credentials->'wrapped') as items(seqno text) where items.seqno = :seqNo")


### PR DESCRIPTION
When loading partner from PartnerRepository found by Id, the Partner object contains tags.
When found by connection Id and other Ids, the partner does not contain tags.
This merge requests adds annotations to some other findBy functions to let the partner contain tags.

<a href="https://gitpod.io/#https://github.com/hyperledger-labs/business-partner-agent/pull/779"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

