### PR TITLE
Fix default schema creation when multi ledger support is enabled

### DIFF
--- a/backend/business-partner-agent/pom.xml
+++ b/backend/business-partner-agent/pom.xml
@@ -133,7 +133,7 @@
         <dependency>
             <groupId>network.idu.acapy</groupId>
             <artifactId>aries-client-python</artifactId>
-            <version>0.7.28-SNAPSHOT</version>
+            <version>0.7.28</version>
         </dependency>
         <dependency>
             <groupId>org.hyperledger.business-partner-agent</groupId>

--- a/backend/business-partner-agent/pom.xml
+++ b/backend/business-partner-agent/pom.xml
@@ -133,7 +133,7 @@
         <dependency>
             <groupId>network.idu.acapy</groupId>
             <artifactId>aries-client-python</artifactId>
-            <version>0.7.27</version>
+            <version>0.7.28-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.hyperledger.business-partner-agent</groupId>
@@ -160,7 +160,7 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-crypto</artifactId>
-            <version>5.7.2</version>
+            <version>5.7.3</version>
         </dependency>
         <dependency>
             <groupId>org.mapstruct</groupId>

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/config/AcaPyConfig.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/config/AcaPyConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 - for information on the respective copyright owner
+ * Copyright (c) 2020-2022 - for information on the respective copyright owner
  * see the NOTICE file and/or the repository at
  * https://github.com/hyperledger-labs/business-partner-agent
  *

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/config/AcaPyConfig.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/config/AcaPyConfig.java
@@ -23,10 +23,8 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.hyperledger.aries.AriesClient;
-import org.hyperledger.aries.api.server.AdminConfig;
 import org.hyperledger.bpa.impl.StartupTasks;
 
 import java.io.IOException;
@@ -55,24 +53,20 @@ public class AcaPyConfig implements ApplicationEventListener<StartupTasks.AcaPyR
     @Override
     public void onApplicationEvent(StartupTasks.AcaPyReady event) {
         try {
-            ac.statusConfig().ifPresent(c -> {
-                autoAcceptInvites = resolveFromConfig(c, "debug.auto_accept_invites");
-                autoAcceptRequests = resolveFromConfig(c, "debug.auto_accept_requests");
-                autoRespondMessages = resolveFromConfig(c, "debug.auto_respond_messages");
-                autoRespondCredentialOffer = resolveFromConfig(c, "debug.auto_respond_credential_offer");
-                autoRespondCredentialProposal = resolveFromConfig(c, "debug.auto_respond_credential_proposal");
-                autoRespondCredentialRequest = resolveFromConfig(c, "debug.auto_respond_credential_request");
-                autoRespondPresentationProposal = resolveFromConfig(c, "debug.auto_respond_presentation_proposal");
-                autoRespondPresentationRequest = resolveFromConfig(c, "debug.auto_respond_presentation_request");
-                autoStoreCredential = resolveFromConfig(c, "debug.auto_store_credential");
-                autoVerifyPresentation = resolveFromConfig(c, "debug.auto_verify_presentation");
+            ac.statusConfigTyped().ifPresent(c -> {
+                autoAcceptInvites = c.isAutoAcceptInvites();
+                autoAcceptRequests = c.isAutoAcceptRequests();
+                autoRespondMessages = c.isAutoRespondMessages();
+                autoRespondCredentialOffer = c.isAutoRespondCredentialOffer();
+                autoRespondCredentialProposal = c.isAutoRespondCredentialProposal();
+                autoRespondCredentialRequest = c.isAutoRespondCredentialRequest();
+                autoRespondPresentationProposal = c.isAutoRespondPresentationProposal();
+                autoRespondPresentationRequest = c.isAutoRespondPresentationRequest();
+                autoStoreCredential = c.isAutoStoreCredential();
+                autoVerifyPresentation = c.isAutoVerifyPresentation();
             });
         } catch (IOException e) {
             log.warn("aca-py not reachable");
         }
-    }
-
-    private static Boolean resolveFromConfig(@NonNull AdminConfig c, @NonNull String key) {
-        return Boolean.TRUE.equals(c.getUnwrapped(key, Boolean.class));
     }
 }

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/config/SchemaConfig.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/config/SchemaConfig.java
@@ -43,6 +43,7 @@ public class SchemaConfig {
 
     private String label;
     private String id;
+    private String ledgerId;
     private String defaultAttributeName;
     // Generic structure - [{key: value, key: value}, {key: value}]
     private List<Map<String, String>> restrictions;

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/aries/credential/HolderIndyManager.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/aries/credential/HolderIndyManager.java
@@ -158,7 +158,7 @@ public class HolderIndyManager {
         if (credEx instanceof V1CredentialExchange) {
             schemaId = ((V1CredentialExchange) credEx).getSchemaId();
         } else if (credEx instanceof V20CredExRecord) {
-            schemaId = V2ToV1IndyCredentialConverter.INSTANCE()
+            schemaId = V2ToV1IndyCredentialConverter
                     .toV1Offer((V20CredExRecord) credEx).getCredentialProposalDict().getSchemaId();
         }
         if (schemaId != null) {

--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/aries/schema/SchemaService.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/aries/schema/SchemaService.java
@@ -37,6 +37,7 @@ import org.hyperledger.bpa.api.exception.NetworkException;
 import org.hyperledger.bpa.api.exception.SchemaException;
 import org.hyperledger.bpa.api.exception.WrongApiUsageException;
 import org.hyperledger.bpa.config.BPAMessageSource;
+import org.hyperledger.bpa.config.RuntimeConfig;
 import org.hyperledger.bpa.config.SchemaConfig;
 import org.hyperledger.bpa.controller.api.admin.AddTrustedIssuerRequest;
 import org.hyperledger.bpa.impl.aries.jsonld.LDContextResolver;
@@ -73,6 +74,9 @@ public class SchemaService {
 
     @Inject
     Identity id;
+
+    @Inject
+    RuntimeConfig runtimeConfig;
 
     @Inject
     BPAMessageSource.DefaultMessageSource ms;
@@ -263,11 +267,11 @@ public class SchemaService {
                     dbSchema -> log.debug("Schema with id {} already exists", schema.getId()),
                     () -> {
                         try {
-                            SchemaAPI schemaAPI;
+                            SchemaAPI schemaAPI = null;
                             if (CredentialType.JSON_LD.equals(schema.getType())) {
                                 schemaAPI = addJsonLDSchema(schema.getId(), schema.getLabel(),
                                         schema.getDefaultAttributeName(), schema.getLdType(), schema.getAttributes());
-                            } else {
+                            } else if (StringUtils.equals(runtimeConfig.getWriteLedgerId(), schema.getLedgerId())) {
                                 schemaAPI = addIndySchema(schema.getId(), schema.getLabel(),
                                         schema.getDefaultAttributeName());
                             }

--- a/backend/business-partner-agent/src/main/resources/schemas.yml
+++ b/backend/business-partner-agent/src/main/resources/schemas.yml
@@ -2,6 +2,7 @@ bpa:
   schemas:
     #test ledger schemas, can be overwritten / extended when e.g. working with other ledger
     bank-account:
+      ledgerId: "BoschTest"
       id: "M6Mbe3qx7vB4wpZF4sBRjt:2:bank_account:1.0"
       label: "Bank Account"
       defaultAttributeName: "iban"
@@ -10,6 +11,7 @@ bpa:
         - issuerDid: "${bpa.did.prefix}M6Mbe3qx7vB4wpZF4sBRjt"
           label: "Demo Bank"
     commercial-register:
+      ledgerId: "BoschTest"
       id: "5mwQSWnRePrZ3oF67C4KqD:2:commercialregister:1.0"
       label: "Commercial Register"
       defaultAttributeName: "companyName"

--- a/backend/business-partner-agent/src/test/java/org/hyperledger/bpa/BaseTest.java
+++ b/backend/business-partner-agent/src/test/java/org/hyperledger/bpa/BaseTest.java
@@ -58,7 +58,8 @@ public abstract class BaseTest {
     public static void waitForVP(@NonNull VPManager vpMgmt, boolean waitForVC) throws Exception {
         Instant timeout = Instant.now().plusSeconds(30);
         while (vpMgmt.getVerifiablePresentation().isEmpty()
-                || (waitForVC && vpMgmt.getVerifiablePresentation().get().getVerifiableCredential() == null)) {
+                || (waitForVC && CollectionUtils
+                        .isEmpty(vpMgmt.getVerifiablePresentation().get().getVerifiableCredential()))) {
             Thread.sleep(15);
             if (Instant.now().isAfter(timeout)) {
                 fail("Timeout reached while waiting for the VP to be created");

--- a/backend/business-partner-agent/src/test/java/org/hyperledger/bpa/RunWithAries.java
+++ b/backend/business-partner-agent/src/test/java/org/hyperledger/bpa/RunWithAries.java
@@ -47,17 +47,17 @@ public abstract class RunWithAries extends BaseTest {
     private static final GenericContainer<?> ariesContainer = new GenericContainer<>(ARIES_VERSION)
             .withExposedPorts(ARIES_ADMIN_PORT)
             .withCommand("start"
-                        + " -it http 0.0.0.0 8030"
-                        + " -ot http --admin 0.0.0.0 " + ARIES_ADMIN_PORT
-                        + " --admin-insecure-mode"
-                        + " -e http://0.0.0.0"
-                        + " --log-level info"
-                        + " --no-ledger"
-                        + " --wallet-type askar"
-                        + " --wallet-name testWallet"
-                        + " --wallet-key testKey"
-                        + " --auto-provision"
-                        + " --plugin aries_cloudagent.messaging.jsonld")
+                    + " -it http 0.0.0.0 8030"
+                    + " -ot http --admin 0.0.0.0 " + ARIES_ADMIN_PORT
+                    + " --admin-insecure-mode"
+                    + " -e http://0.0.0.0"
+                    + " --log-level info"
+                    + " --no-ledger"
+                    + " --wallet-type askar"
+                    + " --wallet-name testWallet"
+                    + " --wallet-key testKey"
+                    + " --auto-provision"
+                    + " --plugin aries_cloudagent.messaging.jsonld")
             .waitingFor(Wait.defaultWaitStrategy())
             .withLogConsumer(new Slf4jLogConsumer(log));
 

--- a/backend/business-partner-agent/src/test/java/org/hyperledger/bpa/RunWithAries.java
+++ b/backend/business-partner-agent/src/test/java/org/hyperledger/bpa/RunWithAries.java
@@ -34,6 +34,7 @@ import java.net.URL;
 public abstract class RunWithAries extends BaseTest {
 
     private static final String ARIES_VERSION = "bcgovimages/aries-cloudagent:py36-1.16-1_0.7.4";
+
     /** Container local port, the mapped port is random */
     private static final Integer ARIES_ADMIN_PORT = 8031;
 
@@ -43,13 +44,9 @@ public abstract class RunWithAries extends BaseTest {
     private String url;
 
     @Container
-    private final GenericContainer<?> ariesContainer;
-
-    @SuppressWarnings("resource")
-    public RunWithAries() {
-        ariesContainer = new GenericContainer<>(ARIES_VERSION)
-                .withExposedPorts(ARIES_ADMIN_PORT)
-                .withCommand("start"
+    private static final GenericContainer<?> ariesContainer = new GenericContainer<>(ARIES_VERSION)
+            .withExposedPorts(ARIES_ADMIN_PORT)
+            .withCommand("start"
                         + " -it http 0.0.0.0 8030"
                         + " -ot http --admin 0.0.0.0 " + ARIES_ADMIN_PORT
                         + " --admin-insecure-mode"
@@ -61,9 +58,11 @@ public abstract class RunWithAries extends BaseTest {
                         + " --wallet-key testKey"
                         + " --auto-provision"
                         + " --plugin aries_cloudagent.messaging.jsonld")
-                .waitingFor(Wait.defaultWaitStrategy())
-                .withLogConsumer(new Slf4jLogConsumer(log));
+            .waitingFor(Wait.defaultWaitStrategy())
+            .withLogConsumer(new Slf4jLogConsumer(log));
 
+    @SuppressWarnings("resource")
+    public RunWithAries() {
         runWithProxyIfConfigured(ariesContainer);
     }
 

--- a/backend/business-partner-agent/src/test/java/org/hyperledger/bpa/impl/MyDocumentManagerTest.java
+++ b/backend/business-partner-agent/src/test/java/org/hyperledger/bpa/impl/MyDocumentManagerTest.java
@@ -229,7 +229,7 @@ class MyDocumentManagerTest extends RunWithAries {
         assertFalse(vp.isPresent());
 
         final MyDocumentAPI vc = createAndSavePublicDummyCredential();
-        waitForVP(vpMgmt, false);
+        waitForVP(vpMgmt, true);
 
         vp = vpMgmt.getVerifiablePresentation();
         assertTrue(vp.isPresent());

--- a/backend/business-partner-agent/src/test/java/org/hyperledger/bpa/impl/aries/credential/CredentialTestUtils.java
+++ b/backend/business-partner-agent/src/test/java/org/hyperledger/bpa/impl/aries/credential/CredentialTestUtils.java
@@ -20,6 +20,7 @@ package org.hyperledger.bpa.impl.aries.credential;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.NonNull;
 import org.hyperledger.bpa.api.CredentialType;
 import org.hyperledger.bpa.api.MyDocumentAPI;
 
@@ -31,7 +32,8 @@ public class CredentialTestUtils {
         mapper = m;
     }
 
-    public MyDocumentAPI createDummyCred(CredentialType credType, Boolean isPublic) throws JsonProcessingException {
+    public MyDocumentAPI createDummyCred(@NonNull CredentialType credType, @NonNull Boolean isPublic)
+            throws JsonProcessingException {
         String json = "{ \"iban\":\"Hello\" }";
         JsonNode jsonNode = mapper.readTree(json);
         return MyDocumentAPI.builder()

--- a/frontend/backend-types.ts
+++ b/frontend/backend-types.ts
@@ -1121,6 +1121,7 @@ export interface components {
       host?: string;
       ledgerBrowser?: string;
       ledgerPrefix?: string;
+      writeLedgerId?: string;
       webOnly?: boolean;
       acapyEndpoint?: string;
       imprint?: string;

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -450,6 +450,7 @@
         "uniResolverUrl": "Universal Resolver",
         "ledgerBrowser": "Ledger Browser",
         "ledgerPrefix": "Ledger DID Prefix",
+        "writeLedgerId": "Write Ledger ID",
         "uptime": "Betriebszeit HH:mm:ss.SSS",
         "buildVersion": "Version"
       },

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -451,6 +451,7 @@
         "uniResolverUrl": "Universal Resolver",
         "ledgerBrowser": "Ledger Browser",
         "ledgerPrefix": "Ledger DID Prefix",
+        "writeLedgerId": "Write Ledger ID",
         "uptime": "Uptime HH:mm:ss.SSS",
         "buildVersion": "Version"
       },

--- a/frontend/src/locales/pl.json
+++ b/frontend/src/locales/pl.json
@@ -449,6 +449,7 @@
         "uniResolverUrl": "Universal Resolver",
         "ledgerBrowser": "Ledger Browser",
         "ledgerPrefix": "Ledger DID Prefix",
+        "writeLedgerId": "Write Ledger ID",
         "uptime": "Uptime HH:mm:ss.SSS",
         "buildVersion": "Version"
       },

--- a/frontend/src/views/settings/Settings.vue
+++ b/frontend/src/views/settings/Settings.vue
@@ -183,6 +183,10 @@ export default {
           value: "ledgerPrefix",
         },
         {
+          text: this.$t("view.settings.header.writeLedgerId"),
+          value: "writeLedgerId",
+        },
+        {
           text: this.$t("view.settings.header.uptime"),
           value: "uptime",
         },


### PR DESCRIPTION
The default schemas are created when a) the schemas.yml config is enabled and b) if the schema is found on any ledger. This logic did not consider if the ledger where the default schema resides is the write/production ledger. So the creation of credential definition failed in some cases. As a fix the schema config now has a ledgerId and only if the ledgerId matches the writeLedgerId the default schema is loaded.

Related client changes: https://github.com/hyperledger-labs/acapy-java-client/pull/60/files

<a href="https://gitpod.io/#https://github.com/hyperledger-labs/business-partner-agent/pull/811"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

