### PR TITLE
Use same BPA image for all instances in local scenario

### DIFF
--- a/scripts/scenarios/local-network/docker-compose.yml
+++ b/scripts/scenarios/local-network/docker-compose.yml
@@ -4,7 +4,7 @@ services:
 # Business 1
 #######
   bpa1:
-    image: ghcr.io/hyperledger-labs/business-partner-agent:local
+    image: bpa:local
     build:
       context: ../../..
       dockerfile: Dockerfile
@@ -89,6 +89,7 @@ services:
 # Business 2
 #######
   bpa2:
+    image: bpa:local
     build:
       context: ../../..
       dockerfile: Dockerfile


### PR DESCRIPTION
Signed-off-by: Tim Schlagenhaufer <tim.schlagenhaufer@bosch.io>

Use the same locally built image for both BPAs in the local scenario