### PR TITLE
Answer presentation request with self attested attributes (FE)

### DIFF
--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/util/Converter.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/util/Converter.java
@@ -252,7 +252,9 @@ public class Converter {
                                     .proofType(e.getValue().getType())
                                     .revealedAttributes(e.getValue().getRevealedAttributes())
                                     .requestedPredicates(e.getValue().getRequestedPredicates())
-                                    .identifier(credentialInfoResolver.populateIdentifier(e.getValue().getIdentifier()))
+                                    .identifier(e.getValue().getIdentifier() != null ?
+                                            credentialInfoResolver.populateIdentifier(e.getValue().getIdentifier())
+                                            : null)
                                     .build()));
                     proofData = mapper.convertValue(collect, JsonNode.class);
                 } else if (p.typeIsJsonLd()) {
@@ -263,8 +265,9 @@ public class Converter {
                                 AriesProofExchange.RevealedAttributeGroup ag = AriesProofExchange.RevealedAttributeGroup
                                         .builder()
                                         .revealedAttributes(vc.subjectToFlatMap())
-                                        .identifier(credentialInfoResolver
-                                                .populateIdentifier(LDContextHelper.findSchemaId(vc), vc.getIssuer()))
+                                        .identifier(vc.getIssuer() != null ? credentialInfoResolver
+                                                .populateIdentifier(LDContextHelper.findSchemaId(vc), vc.getIssuer())
+                                                : null)
                                         .build();
                                 return new AbstractMap.SimpleEntry<>(sub.getId(), ag);
                             }).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -54,6 +54,7 @@
         <skip.docker.build>true</skip.docker.build>
         <!-- Dependency Versions -->
         <jackson.version>2.13.4</jackson.version>
+        <jackson.databind.version>2.13.4.2</jackson.databind.version>
         <log4j2.version>2.19.0</log4j2.version>
         <lombok.version>1.18.24</lombok.version>
         <lombok.maven.plugin.version>1.18.20.1</lombok.maven.plugin.version>
@@ -136,7 +137,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${jackson.version}</version>
+                <version>${jackson.databind.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -57,15 +57,15 @@
         <log4j2.version>2.19.0</log4j2.version>
         <lombok.version>1.18.24</lombok.version>
         <lombok.maven.plugin.version>1.18.20.1</lombok.maven.plugin.version>
-        <micronaut.version>3.7.1</micronaut.version>
+        <micronaut.version>3.7.2</micronaut.version>
         <micronaut.data.version>3.8.1</micronaut.data.version>
         <micronaut.openapi.version>4.5.2</micronaut.openapi.version>
         <micronaut.security.version>3.8.0</micronaut.security.version>
-        <mockito.version>4.8.0</mockito.version>
+        <mockito.version>4.8.1</mockito.version>
         <okhttp.version>4.10.0</okhttp.version>
         <org.mapstruct.version>1.5.2.Final</org.mapstruct.version>
         <pmd.version>6.50.0</pmd.version>
-        <spotbugs.version>4.7.2</spotbugs.version>
+        <spotbugs.version>4.7.3</spotbugs.version>
         <testcontainers.version>1.17.5</testcontainers.version>
         <!-- Plugin Versions -->
         <license-maven-plugin.version>4.1</license-maven-plugin.version>

--- a/docs/source/concepts/jwt_validation.md
+++ b/docs/source/concepts/jwt_validation.md
@@ -1,0 +1,182 @@
+# JWT Token Validation
+
+JSON Web Token (JWT) is a term standing for two implementations: JSON Web Signature (JWS) and JSON Web Encryption (JWE). 
+JWE is not very common, and most of the time you will see JWS.
+
+## JWS Basics
+
+A token consists of three parts:
+
+1. Header
+2. Payload
+3. Signature
+
+Header and Payload are base64 encoded JSON documents whose contents are based on [RFC7519](https://tools.ietf.org/html/rfc7519). 
+The signature is created by hashing header and payload and then signing the result with a private key and base64 encoding the result. 
+The JWS presentation is built by concatenating all three parts with dots in between, so in short the result looks like: 
+Concat(Base64(Header) + '.' + Base64(Payload) + '.' + Base64(Signature).
+
+Note: To restrict parsing effort the CA only allows EdDSA as the signature algorithm with an Ed25519 key pair.
+
+## JWS in a regular (web-) service context
+
+To verify the token, you need the public key of the signing party. 
+In a web service context this key is usually statically configured and only changes when the key is rotated or expired. 
+As both header and payload are part of the signature any manipulation of the header or the payload becomes evident immediately.
+
+## JWS in the context of business-partner-agent:web
+
+Here we have the issue that the public key is delivered separately from the token, this opens possibilities for manipulation. 
+In this context we have the following token retrieval and validation process:
+
+* Step 1. Resolve the public profile service endpoint via the did document
+
+This depends on the did method, so the did document can be written on a ledger or made available by a web service. 
+As did document presentations are not always the same, resolution happens with the help of the universal resolver, 
+that (hopefully) returns a normalised presentation of the did document.
+
+Example did document with a profile type endpoint within the service section:
+```json
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1"
+  ],
+  "id": "did:sov:F6dB7dMVHUQSC64qemnBi7",
+  "verificationMethod": [
+    {
+      "id": "did:sov:F6dB7dMVHUQSC64qemnBi7#key-1",
+      "type": "Ed25519VerificationKey2018",
+      "controller": "did:sov:F6dB7dMVHUQSC64qemnBi7",
+      "publicKeyBase58": "8gdhRLtvJHzKoJGyuEqgdN1QZGYfai4wMHFGgtfDXg3D"
+    }
+  ],
+  "service": [
+    {
+      "id": "did:sov:F6dB7dMVHUQSC64qemnBi7#did-communication",
+      "type": "did-communication",
+      "serviceEndpoint": "http://localhost:8080",
+      "recipientKeys": [
+        "did:sov:F6dB7dMVHUQSC64qemnBi7#key-1"
+      ],
+      "routingKeys": [],
+      "priority": 1
+    },
+    {
+      "id": "did:sov:F6dB7dMVHUQSC64qemnBi7#profile",
+      "type": "profile",
+      "serviceEndpoint": "http://localhost:8080/profile.jsonld"
+    }
+  ]
+}
+```
+
+* Step 2. Resolve the public profile
+
+In this case the profile service endpoint returns a JSON structure that contains the JWT.
+
+```
+{
+  "decoded": {},
+  "jwt": ""
+}
+```
+
+* Step 3. Decode token and verify signature
+
+Decoding just means breaking the token down into the three parts mentioned above and verifying its integrity. 
+Verification is the tricky part though.
+
+* Step 4. Resolve the public key
+
+If the token is self-signed the key is already part of the did document. 
+If the token was signed by a third party the public key needs to be resolved by pulling the did document of the third party.
+
+### Token verification scenarios
+
+A token can be either self-signed or signed by a third party. 
+Self-signed in the context of verifiable credentials means subject (sub) == issuer (iss). 
+In JWT terms iss === sub. In general, we have to decide if we want to trust an issuer to make specific claim about a subject. 
+In the self-signed public profile data case we have (human) trust if issuer == subject. 
+But in some cases we would probably not trust did:indy:1 making claims about did:indy:2.
+
+The second step is cryptographic trust, to check if the issuer authenticated the credential. 
+This is the part where we have to check that the public key which verifies the JWT is authorized by the issuer. 
+Therefore, we have to check if the verifying public key is part of the did document of the issuer
+
+Therefore, we can state that:
+
+1. If there is no kid and iss == sub then the token is considered self-signed
+2. If kid && iss == sub then the token is also considered self-signed, and kid must be part of the issuers did document
+3. If sub != iss the token is signed by a third party
+4. If kid && sub != iss, the token is signed by a third party, and kid must be part of the issuers did document
+
+
+#### Self-signed - no key id in the header
+
+If the JWT is in the following form:
+
+```jsom
+{
+  "typ": "JWT",
+  "alg": "EdDSA"
+},
+{
+  "sub": "did:web:faber.iil.network",
+  "iss": "did:web:faber.iil.network"
+}
+```
+
+The did document must only contain a single key. If there is more than one key element the token is considered invalid. 
+If the structure is valid the token signature is validated with the value of "publicKeyBase58".
+
+```json
+{
+  "id": "did:web:faber.iil.network",
+  "publicKey": [
+    {
+      "id": "did:web:faber.iil.network#key-1",
+      "type": "Ed25519VerificationKey2018",
+      "publicKeyBase58": "24j9iYZTPRE3L4W5kRixBAEQLHJzfzuHsqiQyCnVEbKZ"
+    }
+  ]
+}
+```
+
+#### Self-signed - key id in the header
+
+If the header contains a kid...
+
+```
+{
+  "kid": "did:web:faber.iil.network#key-1",
+  "typ": "JWT",
+  "alg": "EdDSA"
+},
+{
+  "sub": "did:web:faber.iil.network",
+  "iss": "did:web:faber.iil.network"
+}
+```
+
+...the did document is allowed to have multiple keys. If the did document is missing a matching publicKey:id the token is considered invalid.
+
+```json
+{
+  "id": "did:web:faber.iil.network",
+  "publicKey": [
+    {
+      "id": "did:web:faber.iil.network#key-1",
+      "type": "Ed25519VerificationKey2018",
+      "publicKeyBase58": "24j9iYZTPRE3L4W5kRixBAEQLHJzfzuHsqiQyCnVEbKZ"
+    }
+  ]
+}
+```
+
+#### Signed by third party
+
+Like mentioned above, the public key needs to be resolved by yet another call to the universal resolver to retrieve 
+the did document and public key of the third party. The `did` used for resolution is taken from the iss field of the Payload. 
+If there is a kid then the same mechanism as above is applied.
+
+This use-case is currently out of scope and validation will fail.

--- a/frontend/src/components/CredentialCard.vue
+++ b/frontend/src/components/CredentialCard.vue
@@ -12,7 +12,9 @@
       height="40"
       class="light-blue darken-3 card-title text-subtitle-1 white--text font-weight-medium"
       style="text-transform: capitalize"
-      >{{ this.document.proofData.identifier.schemaLabel }}</v-card-title
+      >{{
+        hasIdentifiers ? this.document.proofData.identifier.schemaLabel : ""
+      }}</v-card-title
     >
     <v-card-subtitle
       class="light-blue darken-3 card-title text-subtitle-2 white--text font-weight-thin"
@@ -51,7 +53,7 @@
           </v-col>
         </v-row>
       </v-container>
-      <v-expansion-panels flat>
+      <v-expansion-panels flat v-if="hasIdentifiers">
         <v-expansion-panel>
           <v-expansion-panel-header class="font-weight-medium">
             {{ $t("component.credentialCard.details") }}
@@ -104,6 +106,9 @@ export default {
   computed: {
     predicates() {
       return this.document.proofData.requestedPredicates;
+    },
+    hasIdentifiers() {
+      return this.document.proofData.identifier;
     },
     unrevealedAttributes() {
       return (

--- a/frontend/src/components/PresentationExList.vue
+++ b/frontend/src/components/PresentationExList.vue
@@ -96,6 +96,7 @@
             class="justify-start"
             v-else
             v-bind:record="record"
+            :isReadyToApprove.sync="isReadyToApprove"
           ></PresentationRecord>
           <v-alert
             v-if="
@@ -198,11 +199,12 @@ export default {
       dialog: false,
       isBusy: false,
       isLoadingPresExRecords: true,
+      isWaitingForMatchingCreds: false,
+      isReadyToApprove: false,
       presentationExchangeRecords: new Array<AriesProofExchange>(),
       options: {},
       totalNumberOfElements: 0,
       hideFooter: false,
-      isWaitingForMatchingCreds: false,
       declineReasonText: "",
     };
   },
@@ -266,18 +268,6 @@ export default {
         this.record.state &&
         this.record.state === PresentationExchangeStates.REQUEST_RECEIVED
       );
-    },
-    // TODO
-    isReadyToApprove() {
-      if (Object.hasOwnProperty.call(this.record, "proofRequest")) {
-        const groupsWithCredentials = RequestTypes.map((type) => {
-          return Object.values(this.record.proofRequest[type]).map((group) => {
-            return Object.hasOwnProperty.call(group, "selectedCredential");
-          });
-        });
-        // eslint-disable-next-line unicorn/no-array-reduce
-        return groupsWithCredentials.flat().reduce((x, y) => x && y);
-      } else return false;
     },
     typeIsIndy() {
       return this.record.type === CredentialTypes.INDY.type;

--- a/frontend/src/components/PresentationExList.vue
+++ b/frontend/src/components/PresentationExList.vue
@@ -267,6 +267,7 @@ export default {
         this.record.state === PresentationExchangeStates.REQUEST_RECEIVED
       );
     },
+    // TODO
     isReadyToApprove() {
       if (Object.hasOwnProperty.call(this.record, "proofRequest")) {
         const groupsWithCredentials = RequestTypes.map((type) => {
@@ -422,10 +423,20 @@ export default {
       RequestTypes.map((type) => {
         Object.entries(this.record.proofRequest[type]).map(
           ([groupName, group]: [string, any]) => {
-            referents[groupName] = {
-              referent: group.selectedCredential?.credentialInfo?.referent,
-              revealed: !!group.revealed,
-            };
+            if (
+              group.selectedCredential &&
+              typeof group.selectedCredential === "object"
+            ) {
+              referents[groupName] = {
+                referent: group.selectedCredential?.credentialInfo?.referent,
+                revealed: !!group.revealed,
+              };
+            } else {
+              referents[groupName] = {
+                selfAttestedValue: group.selectedCredential,
+                revealed: true,
+              };
+            }
           }
         );
       });

--- a/frontend/src/components/PresentationRecord.vue
+++ b/frontend/src/components/PresentationRecord.vue
@@ -171,7 +171,9 @@
                   <v-combobox
                     v-if="group.restrictions.length === 0"
                     :label="
-                      $t('view.presentationRecord.matchingCredentials.label')
+                      $t(
+                        'view.presentationRecord.matchingCredentials.labelSelfAttestation'
+                      )
                     "
                     return-object
                     :items="group.matchingCredentials"

--- a/frontend/src/components/PresentationRecord.vue
+++ b/frontend/src/components/PresentationRecord.vue
@@ -205,6 +205,7 @@
                     "
                     v-model="group.revealed"
                     v-if="group.hasOwnProperty('revealed')"
+                    :disabled="group.canReveal"
                     class="pa-2"
                   ></v-checkbox>
                 </span>
@@ -248,11 +249,19 @@ import {
 } from "@/services";
 export default {
   name: "PresentationRecord",
+  components: { Timeline },
   props: {
     record: {} as AriesProofExchange & {
       stateToTimestampUiTimeline: [string, number][];
     },
     isReadyToApprove: Boolean,
+  },
+  data: () => {
+    return {
+      Predicates,
+      Restrictions,
+      RequestTypes,
+    };
   },
   computed: {
     expertMode() {
@@ -298,8 +307,10 @@ export default {
         this.names(group).map((name: string) => {
           if (credential && typeof credential === "object") {
             group.cvalues[name] = credential.credentialInfo.attrs[name];
+            group.canReveal = false;
           } else {
             group.cvalues[name] = credential;
+            group.canReveal = true;
           }
         });
       }
@@ -308,6 +319,7 @@ export default {
     },
     clearSelectedCredential(group: any) {
       delete group.cvalues;
+      delete group.canReveal;
       delete group.selectedCredential;
     },
     checkIfReadyToApprove() {
@@ -375,13 +387,5 @@ export default {
       return attributeGroupName;
     },
   },
-  data: () => {
-    return {
-      Predicates,
-      Restrictions,
-      RequestTypes,
-    };
-  },
-  components: { Timeline },
 };
 </script>

--- a/frontend/src/components/PresentationRecord.vue
+++ b/frontend/src/components/PresentationRecord.vue
@@ -167,7 +167,7 @@
                   }}
                 </h4>
                 <span class="d-flex align-end">
-                  <v-select
+                  <v-combobox
                     :label="
                       $t('view.presentationRecord.matchingCredentials.label')
                     "
@@ -179,7 +179,9 @@
                     @change="selectCredential(group, $event)"
                     dense
                     class="pa-0"
-                  ></v-select>
+                    clearable
+                  >
+                  </v-combobox>
                   <v-checkbox
                     :label="
                       $t('view.presentationRecord.matchingCredentials.revealed')
@@ -271,10 +273,14 @@ export default {
     },
   },
   methods: {
-    selectCredential(group: any, credential: PresentationRequestCredentials) {
+    selectCredential(group: any, credential: any) {
       group.cvalues = {};
       this.names(group).map((name: string) => {
-        group.cvalues[name] = credential.credentialInfo.attrs[name];
+        if (credential && typeof credential === "object") {
+          group.cvalues[name] = credential.credentialInfo.attrs[name];
+        } else {
+          group.cvalues[name] = credential;
+        }
       });
     },
     names(item: ProofRequestedAttributes): string[] {

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -418,6 +418,7 @@
       "matchingCredentials": {
         "selectHeader": "Daten für die Präsentation auswählen",
         "label": "Passende Berechtigungsnachweise",
+        "labelSelfAttestation": "Passende Berechtigungsnachweise oder selbst ausgestellt",
         "credentialRevoked": " - Berechtigungsnachweis wurde widerrufen",
         "noInfoFound": "Keine Informationen gefunden",
         "revealed": "Offenlegen"

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -418,7 +418,8 @@
       "presentationNotValid": "Presentation is not valid",
       "matchingCredentials": {
         "selectHeader": "Select data for presentation",
-        "label": "Matching Credentials",
+        "label": "Matching credentials",
+        "labelSelfAttestation": "Matching credentials or self attested value",
         "credentialRevoked": " - credential is revoked",
         "noInfoFound": "No info found",
         "revealed": "Reveal"

--- a/frontend/src/locales/pl.json
+++ b/frontend/src/locales/pl.json
@@ -417,6 +417,7 @@
       "matchingCredentials": {
         "selectHeader": "Wybierz dane do prezentacj",
         "label": "Dopasowanie poświadczeń",
+        "labelSelfAttestation": "Matching credentials or self attested value",
         "credentialRevoked": " - poświadczenie jest unieważnione",
         "noInfoFound": "No info found",
         "revealed": "Reveal"


### PR DESCRIPTION
Fixed the verifier side of the UI so that it can handle and display self-attested attributes:

<img width="974" alt="Screenshot 2022-10-20 at 13 00 53" src="https://user-images.githubusercontent.com/13498217/196931475-033fdf38-67ab-4335-bbdf-000481df901c.png">

On the prover side a combobox is displayed in the case that a presentation request has no restrictions on the group:

<img width="958" alt="Screenshot 2022-10-20 at 12 56 51" src="https://user-images.githubusercontent.com/13498217/196931153-3964c011-399a-41f3-98f9-e8acef9b107d.png">


Signed-off-by: Philipp Etschel <philipp.etschel@ch.bosch.com>

<a href="https://gitpod.io/#https://github.com/hyperledger-labs/business-partner-agent/pull/840"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

