### PR TITLE
Fix returned credential exchange id 

### DIFF
--- a/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/aries/credential/IssuerManager.java
+++ b/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/aries/credential/IssuerManager.java
@@ -116,7 +116,7 @@ public class IssuerManager extends CredentialManagerBase {
             throw new WrongApiUsageException();
         }
         fireCredentialIssuedEvent(credEx);
-        return credEx.getCredentialExchangeId();
+        return credEx.getId().toString();
     }
 
     /**


### PR DESCRIPTION
The response of issuing(send) a credential to a holder is the credential exchange id, but the returned id is not the UUID which is needed to refer to the appropriate credential exchange.

Usage:
- this is needed to automate revocation in the load test scenario (jmeter)

Signed-off-by: Driton Goxhufi <driton.goxhufi@bosch.io>

<a href="https://gitpod.io/#https://github.com/hyperledger-labs/business-partner-agent/pull/847"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

