### PR TITLE
Version updates and minor fixes

### DIFF
--- a/backend/business-partner-agent/pom.xml
+++ b/backend/business-partner-agent/pom.xml
@@ -171,7 +171,7 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-crypto</artifactId>
-            <version>5.7.4</version>
+            <version>5.8.0</version>
         </dependency>
         <dependency>
             <groupId>org.mapstruct</groupId>

--- a/backend/business-partner-agent/pom.xml
+++ b/backend/business-partner-agent/pom.xml
@@ -92,12 +92,12 @@
         <dependency>
             <groupId>io.micronaut.redis</groupId>
             <artifactId>micronaut-redis-lettuce</artifactId>
-            <version>5.3.1</version>
+            <version>5.3.2</version>
         </dependency>
         <dependency>
             <groupId>io.micronaut.email</groupId>
             <artifactId>micronaut-email-mailjet</artifactId>
-            <version>1.4.0</version>
+            <version>1.5.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>javax.activation</groupId>
@@ -118,7 +118,7 @@
         <dependency><!-- Overwrite for jakarta-annotations-api -->
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-annotations-api</artifactId>
-            <version>10.1.1</version>
+            <version>10.1.2</version>
         </dependency>
 
         <!-- Logging -->
@@ -144,7 +144,7 @@
         <dependency>
             <groupId>network.idu.acapy</groupId>
             <artifactId>aries-client-python</artifactId>
-            <version>0.7.31</version>
+            <version>0.7.33</version>
         </dependency>
         <dependency>
             <groupId>org.hyperledger.business-partner-agent</groupId>
@@ -188,7 +188,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.5.0</version>
+            <version>42.5.1</version>
         </dependency>
         <dependency>
             <groupId>io.micronaut.flyway</groupId>

--- a/backend/business-partner-agent/src/test/java/org/hyperledger/bpa/RunWithAries.java
+++ b/backend/business-partner-agent/src/test/java/org/hyperledger/bpa/RunWithAries.java
@@ -33,7 +33,7 @@ import java.net.URL;
 @Testcontainers
 public abstract class RunWithAries extends BaseTest {
 
-    private static final String ARIES_VERSION = "bcgovimages/aries-cloudagent:py36-1.16-1_0.7.4";
+    private static final String ARIES_VERSION = "bcgovimages/aries-cloudagent:py36-1.16-1_0.7.5";
 
     /** Container local port, the mapped port is random */
     private static final Integer ARIES_ADMIN_PORT = 8031;
@@ -61,7 +61,6 @@ public abstract class RunWithAries extends BaseTest {
             .waitingFor(Wait.defaultWaitStrategy())
             .withLogConsumer(new Slf4jLogConsumer(log));
 
-    @SuppressWarnings("resource")
     public RunWithAries() {
         runWithProxyIfConfigured(ariesContainer);
     }

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -71,10 +71,10 @@
         <!-- Plugin Versions -->
         <license-maven-plugin.version>4.1</license-maven-plugin.version>
         <maven.compiler.plugin.version>3.10.1</maven.compiler.plugin.version>
-        <maven.dependency.plugin.version>3.3.0</maven.dependency.plugin.version>
+        <maven.dependency.plugin.version>3.4.0</maven.dependency.plugin.version>
         <maven.failsafe.plugin.version>3.0.0-M7</maven.failsafe.plugin.version>
         <maven.pmd.plugin.version>3.19.0</maven.pmd.plugin.version>
-        <maven.spotbugs.plugin.version>4.7.2.1</maven.spotbugs.plugin.version>
+        <maven.spotbugs.plugin.version>4.7.3.0</maven.spotbugs.plugin.version>
         <maven.surefire.plugin.version>3.0.0-M7</maven.surefire.plugin.version>
     </properties>
 
@@ -125,7 +125,7 @@
             <dependency>
                 <groupId>org.flywaydb</groupId>
                 <artifactId>flyway-core</artifactId>
-                <version>9.2.3</version>
+                <version>9.8.3</version>
             </dependency>
 
             <!-- Overwrites for vulnerable dependencies -->
@@ -158,7 +158,7 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>2.0.3</version>
+                <version>2.0.5</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
@@ -270,7 +270,7 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>7.3.0</version>
+                <version>7.4.0</version>
                 <configuration>
                     <failBuildOnAnyVulnerability>false</failBuildOnAnyVulnerability>
                     <skip>true</skip>
@@ -339,7 +339,7 @@
                 <plugin>
                     <groupId>io.micronaut.build</groupId>
                     <artifactId>micronaut-maven-plugin</artifactId>
-                    <version>3.4.0</version>
+                    <version>3.5.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
@@ -359,7 +359,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-install-plugin</artifactId>
-                    <version>3.0.1</version>
+                    <version>3.1.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-site-plugin</artifactId>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -53,21 +53,21 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <skip.docker.build>true</skip.docker.build>
         <!-- Dependency Versions -->
-        <jackson.version>2.13.4</jackson.version>
-        <jackson.databind.version>2.13.4.2</jackson.databind.version>
+        <jackson.version>2.14.1</jackson.version>
+        <jackson.databind.version>2.14.1</jackson.databind.version>
         <log4j2.version>2.19.0</log4j2.version>
         <lombok.version>1.18.24</lombok.version>
         <lombok.maven.plugin.version>1.18.20.1</lombok.maven.plugin.version>
-        <micronaut.version>3.7.2</micronaut.version>
+        <micronaut.version>3.7.4</micronaut.version>
         <micronaut.data.version>3.8.1</micronaut.data.version>
-        <micronaut.openapi.version>4.5.2</micronaut.openapi.version>
-        <micronaut.security.version>3.8.0</micronaut.security.version>
-        <mockito.version>4.8.1</mockito.version>
+        <micronaut.openapi.version>4.7.1</micronaut.openapi.version>
+        <micronaut.security.version>3.8.3</micronaut.security.version>
+        <mockito.version>4.9.0</mockito.version>
         <okhttp.version>4.10.0</okhttp.version>
         <org.mapstruct.version>1.5.3.Final</org.mapstruct.version>
-        <pmd.version>6.50.0</pmd.version>
+        <pmd.version>6.52.0</pmd.version>
         <spotbugs.version>4.7.3</spotbugs.version>
-        <testcontainers.version>1.17.5</testcontainers.version>
+        <testcontainers.version>1.17.6</testcontainers.version>
         <!-- Plugin Versions -->
         <license-maven-plugin.version>4.1</license-maven-plugin.version>
         <maven.compiler.plugin.version>3.10.1</maven.compiler.plugin.version>
@@ -287,7 +287,7 @@
             <plugin>
                 <groupId>net.revelc.code.formatter</groupId>
                 <artifactId>formatter-maven-plugin</artifactId>
-                <version>2.20.0</version>
+                <version>2.21.0</version>
                 <executions>
                     <execution>
                         <goals>

--- a/scripts/.env-example
+++ b/scripts/.env-example
@@ -22,6 +22,7 @@ BPA_SCHEME=https
 BPA_CONFIG_FILES=classpath:application.yml,classpath:schemas.yml
 
 # Security
+# Must be run with TLS
 BPA_SECURITY_ENABLED=true
 # Default username and password, set if running in production like environments
 BPA_BOOTSTRAP_UN=admin

--- a/scripts/.env-example
+++ b/scripts/.env-example
@@ -21,8 +21,9 @@ BPA2_DEBUG_PORT=1045
 BPA_SCHEME=https
 BPA_CONFIG_FILES=classpath:application.yml,classpath:schemas.yml
 
-# Security
-# Must be run with TLS
+# Enable/disable login screen
+# Must be run behind a TLS proxy, if login over plain http is desired
+# -Dmicronaut.session.http.cookie-secure=false needs to be set in the JAVA_OPTS for both bpa1 and bpa2
 BPA_SECURITY_ENABLED=true
 # Default username and password, set if running in production like environments
 BPA_BOOTSTRAP_UN=admin

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -28,7 +28,6 @@ services:
       BPA_IMPRINT_URL: ${BPA_IMPRINT_URL}
       BPA_PRIVACY_POLICY_URL: ${BPA_PRIVACY_POLICY_URL}
       BPA_CREDDEF_REVOCATION_REGISTRY_SIZE: ${BPA_CREDDEF_REVOCATION_REGISTRY_SIZE}
-      BPA_WEBHOOK_KEY: ${BPA_WEBHOOK_KEY}
       # MAIL_USERNAME: ${MAIL_USERNAME}
       # MAILJET_API_KEY: ${MAILJET_API_KEY}
       # MAILJET_API_SECRET: ${MAILJET_API_SECRET}
@@ -36,7 +35,7 @@ services:
       - ${BPA_PORT}:${BPA_PORT}
     restart: always
   bpa-agent1:
-    image: bcgovimages/aries-cloudagent:py36-1.16-1_0.7.4
+    image: bcgovimages/aries-cloudagent:py36-1.16-1_0.7.5
     ports:
       - ${ACAPY_ADMIN_PORT}:${ACAPY_ADMIN_PORT}
       - ${ACAPY_HTTP_PORT}:${ACAPY_HTTP_PORT}
@@ -107,7 +106,6 @@ services:
       BPA_IMPRINT_URL: ${BPA_IMPRINT_URL}
       BPA_PRIVACY_POLICY_URL: ${BPA_PRIVACY_POLICY_URL}
       BPA_CREDDEF_REVOCATION_REGISTRY_SIZE: ${BPA_CREDDEF_REVOCATION_REGISTRY_SIZE}
-      BPA_WEBHOOK_KEY: ${BPA_WEBHOOK_KEY}
       # MAIL_USERNAME: ${MAIL_USERNAME}
       # MAILJET_API_KEY: ${MAILJET_API_KEY}
       # MAILJET_API_SECRET: ${MAILJET_API_SECRET}
@@ -117,7 +115,7 @@ services:
   bpa-agent2:
     profiles:
       - second_bpa
-    image: bcgovimages/aries-cloudagent:py36-1.16-1_0.7.4
+    image: bcgovimages/aries-cloudagent:py36-1.16-1_0.7.5
     ports:
       - ${ACAPY2_ADMIN_PORT}:${ACAPY2_ADMIN_PORT}
       - ${ACAPY2_HTTP_PORT}:${ACAPY2_HTTP_PORT}

--- a/scripts/ngrok.yml
+++ b/scripts/ngrok.yml
@@ -1,4 +1,8 @@
+version: "2"
+
+# region: <your-region> # e.g. us, eu
 # authtoken: <your-token>
+
 tunnels:
     businesspartner:
       proto: http

--- a/scripts/scenarios/keycloak-vcauthn/docker-compose.yaml
+++ b/scripts/scenarios/keycloak-vcauthn/docker-compose.yaml
@@ -49,7 +49,7 @@ services:
      - host.docker.internal:host-gateway
 
   bpa-agent1:
-    image: bcgovimages/aries-cloudagent:py36-1.16-1_0.7.4-rc2
+    image: bcgovimages/aries-cloudagent:py36-1.16-1_0.7.5
     ports:
       - ${ACAPY_ADMIN_PORT}:${ACAPY_ADMIN_PORT}
       - ${ACAPY_HTTP_PORT}:${ACAPY_HTTP_PORT}
@@ -129,7 +129,7 @@ services:
   bpa-agent2:
     profiles:
       - second_bpa
-    image: bcgovimages/aries-cloudagent:py36-1.16-1_0.7.4-rc2
+    image: bcgovimages/aries-cloudagent:py36-1.16-1_0.7.5
     ports:
       - ${ACAPY2_ADMIN_PORT}:${ACAPY2_ADMIN_PORT}
       - ${ACAPY2_HTTP_PORT}:${ACAPY2_HTTP_PORT}

--- a/scripts/scenarios/local-network/docker-compose.yml
+++ b/scripts/scenarios/local-network/docker-compose.yml
@@ -41,7 +41,7 @@ services:
     extra_hosts:
      - host.docker.internal:host-gateway
   bpa-agent1:
-    image: bcgovimages/aries-cloudagent:py36-1.16-1_0.7.4
+    image: bcgovimages/aries-cloudagent:py36-1.16-1_0.7.5
     ports:
       - ${ACAPY1_ADMIN_PORT}:${ACAPY1_ADMIN_PORT}
       - ${ACAPY1_HTTP_PORT}:${ACAPY1_HTTP_PORT}
@@ -126,7 +126,7 @@ services:
     extra_hosts:
      - host.docker.internal:host-gateway
   bpa-agent2:
-    image: bcgovimages/aries-cloudagent:py36-1.16-1_0.7.4
+    image: bcgovimages/aries-cloudagent:py36-1.16-1_0.7.5
     ports:
       - ${ACAPY2_ADMIN_PORT}:${ACAPY2_ADMIN_PORT}
       - ${ACAPY2_HTTP_PORT}:${ACAPY2_HTTP_PORT}


### PR DESCRIPTION
- latest chrome version requires https in case the cookie is set to secure, otherwise the cookie is not stored, which breaks the login screen in case `BPA_SECURITY_ENABLED=true` and the BPA is accessed via `http://localhost:8080`.  Added a comment .env-example on how to workaround this.
- ngrok v3 now requires a version field in ngrok.yml, otherwise the tunnel won't start
- version updates